### PR TITLE
[CALCITE] Update INSERT INTO statement to handle SELECT statements that are in parentheses.

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -282,6 +282,13 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testInsertWithSelectInParens() {
+    final String sql = "insert into foo (SELECT * FROM bar)";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "(SELECT *\nFROM `BAR`)";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testInsertWithoutValuesKeywordSingleRow() {
     final String sql = "insert into foo (1,'hi')";
     final String expected = "INSERT INTO `FOO`\n"


### PR DESCRIPTION
[CALCITE] Update INSERT INTO statement to handle SELECT statements that are in parentheses.

An example query that this would handle is:

insert into foo (a, b) (SELECT * FROM bar)