### PR TITLE
[CALCITE] Modify unparsing order of UPDATE statement for BIG QUERY dialect

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -427,8 +427,8 @@ class BabelParserTest extends SqlParserTest {
   }
 
   @Test public void testUpdateFromTableWithAliasBigQuery() {
-    final String sql = "update foo as f set f.x = b.y, f.z = b.k";
-    final String expected = "UPDATE `foo` AS `f` FROM `bar` AS `b` SET `f`.`x` "
+    final String sql = "update foo as f from bar as b set f.x = b.y, f.z = b.k";
+    final String expected = "UPDATE `foo` AS `f` SET `f`.`x` "
         + "= `b`.`y`, `f`.`z` = `b`.`k` FROM `bar` AS `b`";
     bigQuerySql(sql).ok(expected);
   }

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -432,6 +432,7 @@ class BabelParserTest extends SqlParserTest {
         + "= `b`.`y`, `f`.`z` = `b`.`k` FROM `bar` AS `b`";
     bigQuerySql(sql).ok(expected);
   }
+
   @Test public void testExecMacro() {
     final String sql = "exec foo";
     final String expected = "EXECUTE `FOO`";

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.test;
 
+import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
 import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql.parser.SqlParserTest;
@@ -421,16 +422,20 @@ class BabelParserTest extends SqlParserTest {
 
   @Test public void testUpdateFromTableBigQuery() {
     final String sql = "update foo from bar set foo.x = bar.y, foo.z = bar.k";
-    final String expected = "UPDATE `foo` SET `foo`.`x` = `bar`.`y`, "
-        + "`foo`.`z` = `bar`.`k` FROM `bar`";
-    bigQuerySql(sql).ok(expected);
+    final String expected = "UPDATE foo SET foo.x = bar.y, "
+        + "foo.z = bar.k FROM bar";
+    sql(sql)
+      .withDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect())
+      .ok(expected);
   }
 
   @Test public void testUpdateFromTableWithAliasBigQuery() {
     final String sql = "update foo as f from bar as b set f.x = b.y, f.z = b.k";
-    final String expected = "UPDATE `foo` AS `f` SET `f`.`x` "
-        + "= `b`.`y`, `f`.`z` = `b`.`k` FROM `bar` AS `b`";
-    bigQuerySql(sql).ok(expected);
+    final String expected = "UPDATE foo AS f SET f.x "
+        + "= b.y, f.z = b.k FROM bar AS b";
+    sql(sql)
+      .withDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect())
+      .ok(expected);
   }
 
   @Test public void testExecMacro() {

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -419,6 +419,19 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testUpdateFromTableBigQuery() {
+    final String sql = "update foo from bar set foo.x = bar.y, foo.z = bar.k";
+    final String expected = "UPDATE `FOO` FROM `BAR` SET `FOO`.`X` = `BAR`.`Y`, "
+        + "`FOO`.`Z` = `BAR`.`K`";
+    bigQuerySql(sql).ok(expected);
+  }
+
+  @Test public void testUpdateFromTableWithAliasBigQuery() {
+    final String sql = "update foo as f from bar as b set f.x = b.y, f.z = b.k";
+    final String expected = "UPDATE `FOO` AS `F` FROM `BAR` AS `B` SET `F`.`X` "
+        + "= `B`.`Y`, `F`.`Z` = `B`.`K`";
+    bigQuerySql(sql).ok(expected);
+  }
   @Test public void testExecMacro() {
     final String sql = "exec foo";
     final String expected = "EXECUTE `FOO`";

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -421,15 +421,15 @@ class BabelParserTest extends SqlParserTest {
 
   @Test public void testUpdateFromTableBigQuery() {
     final String sql = "update foo from bar set foo.x = bar.y, foo.z = bar.k";
-    final String expected = "UPDATE `FOO` FROM `BAR` SET `FOO`.`X` = `BAR`.`Y`, "
-        + "`FOO`.`Z` = `BAR`.`K`";
+    final String expected = "UPDATE `foo` SET `foo`.`x` = `bar`.`y`, "
+        + "`foo`.`z` = `bar`.`k` FROM `bar`";
     bigQuerySql(sql).ok(expected);
   }
 
   @Test public void testUpdateFromTableWithAliasBigQuery() {
-    final String sql = "update foo as f from bar as b set f.x = b.y, f.z = b.k";
-    final String expected = "UPDATE `FOO` AS `F` FROM `BAR` AS `B` SET `F`.`X` "
-        + "= `B`.`Y`, `F`.`Z` = `B`.`K`";
+    final String sql = "update foo as f set f.x = b.y, f.z = b.k";
+    final String expected = "UPDATE `foo` AS `f` FROM `bar` AS `b` SET `f`.`x` "
+        + "= `b`.`y`, `f`.`z` = `b`.`k` FROM `bar` AS `b`";
     bigQuerySql(sql).ok(expected);
   }
   @Test public void testExecMacro() {

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -483,7 +483,8 @@ public class SqlDialect {
     }
   }
 
-  public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall, int leftPrec, int rightPrec) {
+  public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall,
+       int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame =
         writer.startList(SqlWriter.FrameTypeEnum.SELECT, "UPDATE", "");
     final int opLeft = updateCall.getOperator().getLeftPrec();

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.sql;
 
-import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -127,7 +127,8 @@ public class BigQuerySqlDialect extends SqlDialect {
     unparseFetchUsingLimit(writer, offset, fetch);
   }
 
-  @Override public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall, int leftPrec, int rightPrec) {
+  @Override public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall,
+      int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame =
         writer.startList(SqlWriter.FrameTypeEnum.SELECT, "UPDATE", "");
     final int opLeft = updateCall.getOperator().getLeftPrec();

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlAlienSystemTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
@@ -36,12 +37,14 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlSetOperator;
 import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.util.Pair;
 
 import com.google.common.collect.ImmutableList;
 
@@ -122,6 +125,43 @@ public class BigQuerySqlDialect extends SqlDialect {
   @Override public void unparseOffsetFetch(SqlWriter writer, SqlNode offset,
       SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
+  }
+
+  @Override public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall, int leftPrec, int rightPrec) {
+    final SqlWriter.Frame frame =
+        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "UPDATE", "");
+    final int opLeft = updateCall.getOperator().getLeftPrec();
+    final int opRight = updateCall.getOperator().getRightPrec();
+    updateCall.getTargetTable().unparse(writer, opLeft, opRight);
+    if (updateCall.getAlias() != null) {
+      writer.keyword("AS");
+      updateCall.getAlias().unparse(writer, opLeft, opRight);
+    }
+    final SqlWriter.Frame setFrame =
+        writer.startList(SqlWriter.FrameTypeEnum.UPDATE_SET_LIST, "SET", "");
+    for (Pair<SqlNode, SqlNode> pair
+        : Pair.zip(updateCall.getTargetColumnList(), updateCall.getSourceExpressionList())) {
+      writer.sep(",");
+      SqlIdentifier id = (SqlIdentifier) pair.left;
+      id.unparse(writer, opLeft, opRight);
+      writer.keyword("=");
+      SqlNode sourceExp = pair.right;
+      sourceExp.unparse(writer, opLeft, opRight);
+    }
+    writer.endList(setFrame);
+    if (updateCall.getSourceTable() != null) {
+      writer.keyword("FROM");
+      updateCall.getSourceTable().unparse(writer, opLeft, opRight);
+      if (updateCall.getSourceAlias() != null) {
+        writer.keyword("AS");
+        updateCall.getSourceAlias().unparse(writer, opLeft, opRight);
+      }
+    }
+    if (updateCall.getCondition() != null) {
+      writer.sep("WHERE");
+      updateCall.getCondition().unparse(writer, opLeft, opRight);
+    }
+    writer.endList(frame);
   }
 
   @Override public void unparseCall(final SqlWriter writer, final SqlCall call, final int leftPrec,

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSetOption;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.dialect.BigQuerySqlDialect;
 import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.test.SqlTests;
@@ -588,6 +589,11 @@ public class SqlParserTest {
   protected Sql sql(String sql) {
     return new Sql(sql, false, null, parser -> { });
   }
+
+  protected Sql bigQuerySql(String sql) {
+    return new Sql(sql, false, new SqlDialect(BigQuerySqlDialect.DEFAULT_CONTEXT), parser -> { });
+  }
+
 
   protected Sql expr(String sql) {
     return new Sql(sql, true, null, parser -> { });

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -594,7 +594,6 @@ public class SqlParserTest {
     return new Sql(sql, false, new SqlDialect(BigQuerySqlDialect.DEFAULT_CONTEXT), parser -> { });
   }
 
-
   protected Sql expr(String sql) {
     return new Sql(sql, true, null, parser -> { });
   }

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -28,7 +28,6 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSetOption;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
-import org.apache.calcite.sql.dialect.BigQuerySqlDialect;
 import org.apache.calcite.sql.parser.impl.SqlParserImpl;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.test.SqlTests;
@@ -588,10 +587,6 @@ public class SqlParserTest {
 
   protected Sql sql(String sql) {
     return new Sql(sql, false, null, parser -> { });
-  }
-
-  protected Sql bigQuerySql(String sql) {
-    return new Sql(sql, false, new SqlDialect(BigQuerySqlDialect.DEFAULT_CONTEXT), parser -> { });
   }
 
   protected Sql expr(String sql) {


### PR DESCRIPTION
Big Query wants statements like `update abc from def set abc.x = def.y, abc.z = def.k;` to be unparsed as `update abc set abc.x = def.y, abc.z = def.k from def;`