### PR TITLE
[CALCITE] Unparse unicode correctly in BigQuery

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -419,6 +419,15 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+
+  @Test void testBigQueryUnicodeUnparsing() {
+    final String sql = "SELECT '¶ÑÍ·'";
+    final String expected = "SELECT '\\u00b6\\u00d1\\u00cd\\u00b7'";
+    sql(sql)
+      .withDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect())
+      .ok(expected);
+  }
+
   @Test public void testOrderByUnparsing() {
     final String sql =
         "(select 1 union all select Salary from Employee) order by Salary limit 1 offset 1";

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -628,7 +628,7 @@ public class SqlDialect {
     buf.append("'");
   }
 
-  private static final char[] HEXITS = {
+  protected static final char[] HEXITS = {
       '0', '1', '2', '3', '4', '5', '6', '7',
       '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
   };

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -107,6 +107,27 @@ public class BigQuerySqlDialect extends SqlDialect {
         || RESERVED_KEYWORDS.contains(val.toUpperCase(Locale.ROOT));
   }
 
+  @Override public void quoteStringLiteralUnicode(StringBuilder buf, String val) {
+    buf.append("'");
+    for (int i = 0; i < val.length(); i++) {
+      char c = val.charAt(i);
+      if (c < 32 || c >= 128) {
+        buf.append("\\u");
+        buf.append(HEXITS[(c >> 12) & 0xf]);
+        buf.append(HEXITS[(c >> 8) & 0xf]);
+        buf.append(HEXITS[(c >> 4) & 0xf]);
+        buf.append(HEXITS[c & 0xf]);
+      } else if (c == '\'' || c == '\\') {
+        buf.append(c);
+        buf.append(c);
+      } else {
+        buf.append(c);
+      }
+    }
+    buf.append("'");
+  }
+
+
   @Override public SqlNode emulateNullDirection(SqlNode node,
       boolean nullsFirst, boolean desc) {
     return emulateNullDirectionWithIsNull(node, nullsFirst, desc);


### PR DESCRIPTION
[CALCITE] Unparse unicode correctly in BigQuery

BQ doesn't support u& unicode literals, but it does support \uXXXX type characters, change to unparse in this way
