### PR TITLE
[CALCITE] Fixed MERGE INTO with INSERT statement unparsing in Big Query

### DIFF
--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -544,10 +544,10 @@ class BabelParserTest extends SqlParserTest {
     final String sql = "merge into t1 a using t2 b on a.x = b.x when matched then "
         + "update set y = b.y when not matched then insert (x,y) values (b.x, b.y)";
     final String expected = "MERGE INTO t1 AS a\n"
-       + "USING t2 AS b\n"
-       + "ON (a.x = b.x)\n"
-       + "WHEN MATCHED THEN UPDATE SET y = b.y\n"
-       + "WHEN NOT MATCHED THEN INSERT (x, y) VALUES (b.x, b.y)";
+        + "USING t2 AS b\n"
+        + "ON (a.x = b.x)\n"
+        + "WHEN MATCHED THEN UPDATE SET y = b.y\n"
+        + "WHEN NOT MATCHED THEN INSERT (x, y) VALUES (b.x, b.y)";
     sql(sql)
       .withDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect())
       .ok(expected);

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -540,6 +540,17 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testMergeInto() {
+    final String sql = "merge into t1 a using t2 b on a.x = b.x when matched then "
+        + "update set y = b.y when not matched then insert (x,y) values (b.x, b.y)";
+    final String expected = "MERGE INTO `T1` AS `A`\n"
+        + "USING `T2` AS `B`\n"
+        + "ON (`A`.`X` = `B`.`X`)\n"
+        + "WHEN MATCHED THEN UPDATE SET `Y` = `B`.`Y`\n"
+        + "WHEN NOT MATCHED THEN INSERT (`X`, `Y`) (VALUES (ROW(`B`.`X`, `B`.`Y`)))";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testMergeIntoBigQuery() {
     final String sql = "merge into t1 a using t2 b on a.x = b.x when matched then "
         + "update set y = b.y when not matched then insert (x,y) values (b.x, b.y)";

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -539,4 +539,17 @@ class BabelParserTest extends SqlParserTest {
     final String expected = "SELECT MOD(`FOO`, `BAR`)";
     sql(sql).ok(expected);
   }
+
+  @Test public void testMergeIntoBigQuery() {
+    final String sql = "merge into t1 a using t2 b on a.x = b.x when matched then "
+        + "update set y = b.y when not matched then insert (x,y) values (b.x, b.y)";
+    final String expected = "MERGE INTO t1 AS a\n"
+       + "USING t2 AS b\n"
+       + "ON (a.x = b.x)\n"
+       + "WHEN MATCHED THEN UPDATE SET y = b.y\n"
+       + "WHEN NOT MATCHED THEN INSERT (x, y) VALUES (b.x, b.y)";
+    sql(sql)
+      .withDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect())
+      .ok(expected);
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -486,7 +486,7 @@ public class SqlDialect {
   public void unparseSqlMergeCall(SqlWriter writer, SqlMerge mergeCall,
       int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame =
-      writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
+        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
     final int opLeft = mergeCall.getOperator().getLeftPrec();
     final int opRight = mergeCall.getOperator().getRightPrec();
     mergeCall.getTargetTable().unparse(writer, opLeft, opRight);

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -482,6 +482,7 @@ public class SqlDialect {
       call.operand(2).unparse(writer, leftPrec, rightPrec);
     }
   }
+
   public void unparseSqlMergeCall(SqlWriter writer, SqlMerge mergeCall,
       int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame =
@@ -512,7 +513,8 @@ public class SqlDialect {
               "");
 
       for (Pair<SqlNode, SqlNode> pair : Pair.zip(
-          mergeCall.getUpdateCall().targetColumnList, mergeCall.getUpdateCall().sourceExpressionList)) {
+          mergeCall.getUpdateCall().targetColumnList,
+          mergeCall.getUpdateCall().sourceExpressionList)) {
         writer.sep(",");
         SqlIdentifier id = (SqlIdentifier) pair.left;
         id.unparse(writer, opLeft, opRight);
@@ -527,10 +529,10 @@ public class SqlDialect {
       writer.newlineAndIndent();
       writer.keyword("WHEN NOT MATCHED THEN INSERT");
       if (mergeCall.getInsertCall().getTargetColumnList() != null) {
-        mergeCall.getInsertCall().getTargetColumnList().unparse(writer, opLeft, opRight);
+        mergeCall.getInsertCall().getTargetColumnList().unparse(writer, opLeft,
+            opRight);
       }
       mergeCall.getInsertCall().getSource().unparse(writer, opLeft, opRight);
-
       writer.endList(frame);
     }
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -483,58 +483,9 @@ public class SqlDialect {
     }
   }
 
-  public void unparseSqlMergeCall(SqlWriter writer, SqlMerge mergeCall,
+  public void unparseSqlInsertSource(SqlWriter writer, SqlInsert insertCall,
       int leftPrec, int rightPrec) {
-    final SqlWriter.Frame frame =
-        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
-    final int opLeft = mergeCall.getOperator().getLeftPrec();
-    final int opRight = mergeCall.getOperator().getRightPrec();
-    mergeCall.getTargetTable().unparse(writer, opLeft, opRight);
-    if (mergeCall.getAlias() != null) {
-      writer.keyword("AS");
-      mergeCall.getAlias().unparse(writer, opLeft, opRight);
-    }
-
-    writer.newlineAndIndent();
-    writer.keyword("USING");
-    mergeCall.getSourceTableRef().unparse(writer, opLeft, opRight);
-
-    writer.newlineAndIndent();
-    writer.keyword("ON");
-    mergeCall.getCondition().unparse(writer, opLeft, opRight);
-
-    if (mergeCall.getUpdateCall() != null) {
-      writer.newlineAndIndent();
-      writer.keyword("WHEN MATCHED THEN UPDATE");
-      final SqlWriter.Frame setFrame =
-          writer.startList(
-              SqlWriter.FrameTypeEnum.UPDATE_SET_LIST,
-              "SET",
-              "");
-
-      for (Pair<SqlNode, SqlNode> pair : Pair.zip(
-          mergeCall.getUpdateCall().targetColumnList,
-          mergeCall.getUpdateCall().sourceExpressionList)) {
-        writer.sep(",");
-        SqlIdentifier id = (SqlIdentifier) pair.left;
-        id.unparse(writer, opLeft, opRight);
-        writer.keyword("=");
-        SqlNode sourceExp = pair.right;
-        sourceExp.unparse(writer, opLeft, opRight);
-      }
-      writer.endList(setFrame);
-    }
-
-    if (mergeCall.getInsertCall() != null) {
-      writer.newlineAndIndent();
-      writer.keyword("WHEN NOT MATCHED THEN INSERT");
-      if (mergeCall.getInsertCall().getTargetColumnList() != null) {
-        mergeCall.getInsertCall().getTargetColumnList().unparse(writer, opLeft,
-            opRight);
-      }
-      mergeCall.getInsertCall().getSource().unparse(writer, opLeft, opRight);
-      writer.endList(frame);
-    }
+    insertCall.getSource().unparse(writer, leftPrec, rightPrec);
   }
 
   public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall,

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -482,6 +482,58 @@ public class SqlDialect {
       call.operand(2).unparse(writer, leftPrec, rightPrec);
     }
   }
+  public void unparseSqlMergeCall(SqlWriter writer, SqlMerge mergeCall,
+      int leftPrec, int rightPrec) {
+    final SqlWriter.Frame frame =
+      writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
+    final int opLeft = mergeCall.getOperator().getLeftPrec();
+    final int opRight = mergeCall.getOperator().getRightPrec();
+    mergeCall.getTargetTable().unparse(writer, opLeft, opRight);
+    if (mergeCall.getAlias() != null) {
+      writer.keyword("AS");
+      mergeCall.getAlias().unparse(writer, opLeft, opRight);
+    }
+
+    writer.newlineAndIndent();
+    writer.keyword("USING");
+    mergeCall.getSourceTableRef().unparse(writer, opLeft, opRight);
+
+    writer.newlineAndIndent();
+    writer.keyword("ON");
+    mergeCall.getCondition().unparse(writer, opLeft, opRight);
+
+    if (mergeCall.getUpdateCall() != null) {
+      writer.newlineAndIndent();
+      writer.keyword("WHEN MATCHED THEN UPDATE");
+      final SqlWriter.Frame setFrame =
+          writer.startList(
+              SqlWriter.FrameTypeEnum.UPDATE_SET_LIST,
+              "SET",
+              "");
+
+      for (Pair<SqlNode, SqlNode> pair : Pair.zip(
+          mergeCall.getUpdateCall().targetColumnList, mergeCall.getUpdateCall().sourceExpressionList)) {
+        writer.sep(",");
+        SqlIdentifier id = (SqlIdentifier) pair.left;
+        id.unparse(writer, opLeft, opRight);
+        writer.keyword("=");
+        SqlNode sourceExp = pair.right;
+        sourceExp.unparse(writer, opLeft, opRight);
+      }
+      writer.endList(setFrame);
+    }
+
+    if (mergeCall.getInsertCall() != null) {
+      writer.newlineAndIndent();
+      writer.keyword("WHEN NOT MATCHED THEN INSERT");
+      if (mergeCall.getInsertCall().getTargetColumnList() != null) {
+        mergeCall.getInsertCall().getTargetColumnList().unparse(writer, opLeft, opRight);
+      }
+      mergeCall.getInsertCall().getSource().unparse(writer, opLeft, opRight);
+
+      writer.endList(frame);
+    }
+  }
 
   public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall,
        int leftPrec, int rightPrec) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
@@ -21,7 +21,6 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.ImmutableNullableList;
-import org.apache.calcite.util.Pair;
 
 import java.util.List;
 
@@ -167,55 +166,7 @@ public class SqlMerge extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    final SqlWriter.Frame frame =
-        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
-    final int opLeft = getOperator().getLeftPrec();
-    final int opRight = getOperator().getRightPrec();
-    targetTable.unparse(writer, opLeft, opRight);
-    if (alias != null) {
-      writer.keyword("AS");
-      alias.unparse(writer, opLeft, opRight);
-    }
-
-    writer.newlineAndIndent();
-    writer.keyword("USING");
-    source.unparse(writer, opLeft, opRight);
-
-    writer.newlineAndIndent();
-    writer.keyword("ON");
-    condition.unparse(writer, opLeft, opRight);
-
-    if (updateCall != null) {
-      writer.newlineAndIndent();
-      writer.keyword("WHEN MATCHED THEN UPDATE");
-      final SqlWriter.Frame setFrame =
-          writer.startList(
-              SqlWriter.FrameTypeEnum.UPDATE_SET_LIST,
-              "SET",
-              "");
-
-      for (Pair<SqlNode, SqlNode> pair : Pair.zip(
-          updateCall.targetColumnList, updateCall.sourceExpressionList)) {
-        writer.sep(",");
-        SqlIdentifier id = (SqlIdentifier) pair.left;
-        id.unparse(writer, opLeft, opRight);
-        writer.keyword("=");
-        SqlNode sourceExp = pair.right;
-        sourceExp.unparse(writer, opLeft, opRight);
-      }
-      writer.endList(setFrame);
-    }
-
-    if (insertCall != null) {
-      writer.newlineAndIndent();
-      writer.keyword("WHEN NOT MATCHED THEN INSERT");
-      if (insertCall.getTargetColumnList() != null) {
-        insertCall.getTargetColumnList().unparse(writer, opLeft, opRight);
-      }
-      insertCall.getSource().unparse(writer, opLeft, opRight);
-
-      writer.endList(frame);
-    }
+    writer.getDialect().unparseSqlMergeCall(writer, this, leftPrec, rightPrec);
   }
 
   public void validate(SqlValidator validator, SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
@@ -21,6 +21,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
 
 import java.util.List;
 
@@ -166,7 +167,55 @@ public class SqlMerge extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    writer.getDialect().unparseSqlMergeCall(writer, this, leftPrec, rightPrec);
+    final SqlWriter.Frame frame =
+        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
+    final int opLeft = getOperator().getLeftPrec();
+    final int opRight = getOperator().getRightPrec();
+    targetTable.unparse(writer, opLeft, opRight);
+    if (alias != null) {
+      writer.keyword("AS");
+      alias.unparse(writer, opLeft, opRight);
+    }
+
+    writer.newlineAndIndent();
+    writer.keyword("USING");
+    source.unparse(writer, opLeft, opRight);
+
+    writer.newlineAndIndent();
+    writer.keyword("ON");
+    condition.unparse(writer, opLeft, opRight);
+
+    if (updateCall != null) {
+      writer.newlineAndIndent();
+      writer.keyword("WHEN MATCHED THEN UPDATE");
+      final SqlWriter.Frame setFrame =
+          writer.startList(
+              SqlWriter.FrameTypeEnum.UPDATE_SET_LIST,
+              "SET",
+              "");
+
+      for (Pair<SqlNode, SqlNode> pair : Pair.zip(
+          updateCall.targetColumnList, updateCall.sourceExpressionList)) {
+        writer.sep(",");
+        SqlIdentifier id = (SqlIdentifier) pair.left;
+        id.unparse(writer, opLeft, opRight);
+        writer.keyword("=");
+        SqlNode sourceExp = pair.right;
+        sourceExp.unparse(writer, opLeft, opRight);
+      }
+      writer.endList(setFrame);
+    }
+
+    if (insertCall != null) {
+      writer.newlineAndIndent();
+      writer.keyword("WHEN NOT MATCHED THEN INSERT");
+      if (insertCall.getTargetColumnList() != null) {
+        insertCall.getTargetColumnList().unparse(writer, opLeft, opRight);
+      }
+      writer.getDialect().unparseSqlInsertSource(writer, insertCall, opLeft, opRight);
+
+      writer.endList(frame);
+    }
   }
 
   public void validate(SqlValidator validator, SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -179,7 +179,8 @@ public class BigQuerySqlDialect extends SqlDialect {
               "");
 
       for (Pair<SqlNode, SqlNode> pair : Pair.zip(
-          mergeCall.getUpdateCall().getTargetColumnList(), mergeCall.getUpdateCall().getSourceExpressionList())) {
+          mergeCall.getUpdateCall().getTargetColumnList(),
+          mergeCall.getUpdateCall().getSourceExpressionList())) {
         writer.sep(",");
         SqlIdentifier id = (SqlIdentifier) pair.left;
         id.unparse(writer, opLeft, opRight);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -28,11 +28,11 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
-import org.apache.calcite.sql.SqlMerge;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOrderBy;
@@ -149,59 +149,9 @@ public class BigQuerySqlDialect extends SqlDialect {
     unparseFetchUsingLimit(writer, offset, fetch);
   }
 
-  @Override public void unparseSqlMergeCall(SqlWriter writer, SqlMerge mergeCall,
+  @Override public void unparseSqlInsertSource(SqlWriter writer, SqlInsert insertCall,
       int leftPrec, int rightPrec) {
-    final SqlWriter.Frame frame =
-        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
-    final int opLeft = mergeCall.getOperator().getLeftPrec();
-    final int opRight = mergeCall.getOperator().getRightPrec();
-    mergeCall.getTargetTable().unparse(writer, opLeft, opRight);
-    if (mergeCall.getAlias() != null) {
-      writer.keyword("AS");
-      mergeCall.getAlias().unparse(writer, opLeft, opRight);
-    }
-
-    writer.newlineAndIndent();
-    writer.keyword("USING");
-    mergeCall.getSourceTableRef().unparse(writer, opLeft, opRight);
-
-    writer.newlineAndIndent();
-    writer.keyword("ON");
-    mergeCall.getCondition().unparse(writer, opLeft, opRight);
-
-    if (mergeCall.getUpdateCall() != null) {
-      writer.newlineAndIndent();
-      writer.keyword("WHEN MATCHED THEN UPDATE");
-      final SqlWriter.Frame setFrame =
-          writer.startList(
-              SqlWriter.FrameTypeEnum.UPDATE_SET_LIST,
-              "SET",
-              "");
-
-      for (Pair<SqlNode, SqlNode> pair : Pair.zip(
-          mergeCall.getUpdateCall().getTargetColumnList(),
-          mergeCall.getUpdateCall().getSourceExpressionList())) {
-        writer.sep(",");
-        SqlIdentifier id = (SqlIdentifier) pair.left;
-        id.unparse(writer, opLeft, opRight);
-        writer.keyword("=");
-        SqlNode sourceExp = pair.right;
-        sourceExp.unparse(writer, opLeft, opRight);
-      }
-      writer.endList(setFrame);
-    }
-
-    if (mergeCall.getInsertCall() != null) {
-      writer.newlineAndIndent();
-      writer.keyword("WHEN NOT MATCHED THEN INSERT");
-      if (mergeCall.getInsertCall().getTargetColumnList() != null) {
-        mergeCall.getInsertCall().getTargetColumnList().unparse(writer, opLeft,
-            opRight);
-      }
-      unparseCall(writer, (SqlCall) mergeCall.getInsertCall().getSource(),
-          opLeft, opRight);
-      writer.endList(frame);
-    }
+    unparseCall(writer, (SqlCall) insertCall.getSource(), leftPrec, rightPrec);
   }
 
   @Override public void unparseSqlUpdateCall(SqlWriter writer, SqlUpdate updateCall,

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -152,7 +152,7 @@ public class BigQuerySqlDialect extends SqlDialect {
   @Override public void unparseSqlMergeCall(SqlWriter writer, SqlMerge mergeCall,
       int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame =
-      writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
+        writer.startList(SqlWriter.FrameTypeEnum.SELECT, "MERGE INTO", "");
     final int opLeft = mergeCall.getOperator().getLeftPrec();
     final int opRight = mergeCall.getOperator().getRightPrec();
     mergeCall.getTargetTable().unparse(writer, opLeft, opRight);


### PR DESCRIPTION
**Original Big Query unparsing:** 
```
MERGE INTO T1 AS A
USING T2 AS B
ON A.X = B.X
WHEN MATCHED THEN UPDATE SET
    Y = B.Y
WHEN NOT MATCHED THEN INSERT (X, Y) (VALUES  (B.X, B.Y))
```

**New Big Query unparsing:**
```
MERGE INTO T1 AS A
USING T2 AS B
ON A.X = B.X
WHEN MATCHED THEN UPDATE SET
    Y = B.Y
WHEN NOT MATCHED THEN INSERT (X, Y) VALUES  (B.X, B.Y)
```
