### PR TITLE
[CALCITE] Omit backticks when unparsing IF keyword in BigQuery SQL dialect.

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -366,6 +366,7 @@ data: {
     # items in this list become non-reserved
     nonReservedKeywordsToAdd: [
       # not in core, added in babel
+      "IF"
       "SEMI"
 
       # The following keywords are reserved in core Calcite,

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -553,4 +553,20 @@ class BabelParserTest extends SqlParserTest {
     final String expected = "SELECT MOD(`FOO`, `BAR`)";
     sql(sql).ok(expected);
   }
+
+  @Test void testIfTokenIsQuotedInAnsi() {
+    final String sql = "select if(x) from foo";
+    final String expected = "SELECT `IF`(`X`)\n"
+        + "FROM `FOO`";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testIfTokenIsNotQuotedInBigQuery() {
+    final String sql = "select if(x) from foo";
+    final String expected = "SELECT if(x)\n"
+        + "FROM foo";
+    sql(sql)
+        .withDialect(SqlDialect.DatabaseProduct.BIG_QUERY.getDialect())
+        .ok(expected);
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -78,7 +78,7 @@ public class BigQuerySqlDialect extends SqlDialect {
               "DEFAULT", "DEFINE", "DESC", "DISTINCT", "ELSE", "END", "ENUM",
               "ESCAPE", "EXCEPT", "EXCLUDE", "EXISTS", "EXTRACT", "FALSE",
               "FETCH", "FOLLOWING", "FOR", "FROM", "FULL", "GROUP", "GROUPING",
-              "GROUPS", "HASH", "HAVING", "IF", "IGNORE", "IN", "INNER",
+              "GROUPS", "HASH", "HAVING", "IGNORE", "IN", "INNER",
               "INTERSECT", "INTERVAL", "INTO", "IS", "JOIN", "LATERAL", "LEFT",
               "LIKE", "LIMIT", "LOOKUP", "MERGE", "NATURAL", "NEW", "NO",
               "NOT", "NULL", "NULLS", "OF", "ON", "OR", "ORDER", "OUTER",


### PR DESCRIPTION
[CALCITE] Omit backticks when unparsing IF keyword in BigQuery SQL dialect.
