### PR TITLE
[CALCITE] Copied SQL Java classes from server/babel into core

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/OnCommitType.java
+++ b/core/src/main/java/org/apache/calcite/sql/OnCommitType.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+/**
+ * Enumerates the types of sets.
+ */
+public enum OnCommitType {
+  /**
+   * ON COMMIT type not specified.
+   */
+  UNSPECIFIED,
+
+  /**
+   * Save the contents of a materialized global temporary table across transactions.
+   */
+  PRESERVE,
+
+  /**
+   * Discard the contents of a materialized global temporary table across transactions.
+   */
+  RELEASE,
+}

--- a/core/src/main/java/org/apache/calcite/sql/SetType.java
+++ b/core/src/main/java/org/apache/calcite/sql/SetType.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+/**
+ * Enumerates the types of sets.
+ */
+public enum SetType {
+  /**
+   * Set type not specified. Defaults to MULTISET in ANSI mode and SET in Teradata mode.
+   */
+  UNSPECIFIED,
+
+  /**
+   * Duplicate rows are not permitted.
+   */
+  SET,
+
+  /**
+   * Duplicate rows are permitted, in compliance with the ANSI SQL:2011 standard.
+   */
+  MULTISET,
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlAttributeDefinition.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlAttributeDefinition.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Parse tree for SqlAttributeDefinition,
+ * which is part of a {@link SqlCreateType}.
+ */
+public class SqlAttributeDefinition extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("ATTRIBUTE_DEF", SqlKind.ATTRIBUTE_DEF);
+
+  final SqlIdentifier name;
+  final SqlDataTypeSpec dataType;
+  final SqlNode expression;
+  final SqlCollation collation;
+
+  /** Creates a SqlAttributeDefinition; use {@link SqlDdlNodes#attribute}. */
+  SqlAttributeDefinition(SqlParserPos pos, SqlIdentifier name,
+      SqlDataTypeSpec dataType, SqlNode expression, SqlCollation collation) {
+    super(pos);
+    this.name = name;
+    this.dataType = dataType;
+    this.expression = expression;
+    this.collation = collation;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableList.of(name, dataType);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    name.unparse(writer, 0, 0);
+    dataType.unparse(writer, 0, 0);
+    if (collation != null) {
+      writer.keyword("COLLATE");
+      collation.unparse(writer);
+    }
+    if (dataType.getNullable() != null && !dataType.getNullable()) {
+      writer.keyword("NOT NULL");
+    }
+    if (expression != null) {
+      writer.keyword("DEFAULT");
+      exp(writer);
+    }
+  }
+
+  // TODO: refactor this to a util class to share with SqlColumnDeclaration
+  private void exp(SqlWriter writer) {
+    if (writer.isAlwaysUseParentheses()) {
+      expression.unparse(writer, 0, 0);
+    } else {
+      writer.sep("(");
+      expression.unparse(writer, 0, 0);
+      writer.sep(")");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCharacterSetToCharacterSet.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCharacterSetToCharacterSet.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * A {@code SqlCharacterSetToCharacterSet} is an AST node that contains
+ * the structure of CharacterSet to CharacterSet token.
+ */
+public class SqlCharacterSetToCharacterSet extends SqlIdentifier {
+  /**
+   * Creates a {@code SqlCharacterSetToCharacterSet}.
+   *
+   * @param charSetNamesPrimitiveArr Primitive string array of two character sets
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCharacterSetToCharacterSet(
+      final String[] charSetNamesPrimitiveArr,
+      final SqlParserPos pos) {
+    super(new ArrayList<>(Arrays.asList(charSetNamesPrimitiveArr)), pos);
+  }
+
+  @Override public void unparse(final SqlWriter writer,
+      final int leftPrec, final int rightPrec) {
+    writer.print(names.get(0) + "_TO_" + names.get(1));
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCheckConstraint.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCheckConstraint.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * Parse tree for {@code UNIQUE}, {@code PRIMARY KEY} constraints.
+ *
+ * <p>And {@code FOREIGN KEY}, when we support it.
+ */
+public class SqlCheckConstraint extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("CHECK", SqlKind.CHECK);
+
+  private final SqlIdentifier name;
+  private final SqlNode expression;
+
+  /** Creates a SqlCheckConstraint; use {@link SqlDdlNodes#check}. */
+  SqlCheckConstraint(SqlParserPos pos, SqlIdentifier name,
+      SqlNode expression) {
+    super(pos);
+    this.name = name; // may be null
+    this.expression = expression;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, expression);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (name != null) {
+      writer.keyword("CONSTRAINT");
+      name.unparse(writer, 0, 0);
+    }
+    writer.keyword("CHECK");
+    if (writer.isAlwaysUseParentheses()) {
+      expression.unparse(writer, 0, 0);
+    } else {
+      writer.sep("(");
+      expression.unparse(writer, 0, 0);
+      writer.sep(")");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlColumnDeclaration.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlColumnDeclaration.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Parse tree for {@code UNIQUE}, {@code PRIMARY KEY} constraints.
+ *
+ * <p>And {@code FOREIGN KEY}, when we support it.
+ */
+public class SqlColumnDeclaration extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL);
+
+  public final SqlIdentifier name;
+  public final SqlDataTypeSpec dataType;
+  public final SqlNode expression;
+  public final ColumnStrategy strategy;
+
+  /** Creates a SqlColumnDeclaration; use {@link SqlDdlNodes#column}. */
+  SqlColumnDeclaration(SqlParserPos pos, SqlIdentifier name,
+      SqlDataTypeSpec dataType, SqlNode expression,
+      ColumnStrategy strategy) {
+    super(pos);
+    this.name = name;
+    this.dataType = dataType;
+    this.expression = expression;
+    this.strategy = strategy;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableList.of(name, dataType);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    name.unparse(writer, 0, 0);
+    dataType.unparse(writer, 0, 0);
+    if (dataType.getNullable() != null && !dataType.getNullable()) {
+      writer.keyword("NOT NULL");
+    }
+    List<SqlColumnAttribute> columnAttributes = dataType.getColumnAttributes();
+    if (columnAttributes != null && !columnAttributes.isEmpty()) {
+      for (SqlColumnAttribute a : columnAttributes) {
+        a.unparse(writer, 0, 0);
+      }
+    }
+    if (expression != null) {
+      switch (strategy) {
+      case VIRTUAL:
+      case STORED:
+        writer.keyword("AS");
+        exp(writer);
+        writer.keyword(strategy.name());
+        break;
+      case DEFAULT:
+        writer.keyword("DEFAULT");
+        exp(writer);
+        break;
+      default:
+        throw new AssertionError("unexpected: " + strategy);
+      }
+    }
+  }
+
+  private void exp(SqlWriter writer) {
+    if (writer.isAlwaysUseParentheses()) {
+      expression.unparse(writer, 0, 0);
+    } else {
+      writer.sep("(");
+      expression.unparse(writer, 0, 0);
+      writer.sep(")");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttribute.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttribute.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttribute</code> is a base class that can be used
+ * to create custom options for the SQL CREATE TABLE function.
+ *
+ * <p>To customize table option unparsing, override the method
+ * {@link #unparse(SqlWriter, int, int)}.
+ */
+public abstract class SqlCreateAttribute {
+  private final SqlParserPos pos;
+
+  /**
+   * Creates a {@code SqlCreateOption}.
+   *
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttribute(SqlParserPos pos) {
+    this.pos = pos;
+  }
+
+  /** Writes a SQL representation of this table option to a writer. */
+  public abstract void unparse(SqlWriter writer, int leftPrec, int rightPrec);
+
+  public SqlParserPos getParserPos() {
+    return pos;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeBlockCompression.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeBlockCompression.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeBlockCompression</code> is a CREATE TABLE option
+ * for the BLOCKCOMPRESSION attribute.
+ */
+public class SqlCreateAttributeBlockCompression extends SqlCreateAttribute {
+
+  private final BlockCompressionOption blockCompressionOption;
+
+  /**
+   * Creates a {@code SqlCreateAttributeBlockCompression}.
+   *
+   * @param blockCompressionOption  The block-level compression option for a table
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeBlockCompression(BlockCompressionOption blockCompressionOption,
+      SqlParserPos pos) {
+    super(pos);
+    this.blockCompressionOption = blockCompressionOption;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("BLOCKCOMPRESSION");
+    writer.sep("=");
+    switch (blockCompressionOption) {
+    case DEFAULT:
+      writer.keyword("DEFAULT");
+      break;
+    case AUTOTEMP:
+      writer.keyword("AUTOTEMP");
+      break;
+    case MANUAL:
+      writer.keyword("MANUAL");
+      break;
+    case NEVER:
+      writer.keyword("NEVER");
+      break;
+    }
+  }
+
+  public enum BlockCompressionOption {
+    /**
+     * Table uses the default block compression setting.
+     */
+    DEFAULT,
+
+    /**
+     * Table uses default block compression setting based on virtual storage temperature.
+     */
+    AUTOTEMP,
+
+    /**
+     * Table uses default block compression setting at time of creation.
+     */
+    MANUAL,
+
+    /**
+     * The table is not block-level compressed.
+     */
+    NEVER,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeChecksum.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeChecksum.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeChecksum</code> is a CREATE TABLE option
+ * for the CHECKSUM attribute.
+ */
+public class SqlCreateAttributeChecksum extends SqlCreateAttribute {
+
+  private final ChecksumEnabled checksumEnabled;
+
+  /**
+   * Creates a {@code SqlCreateAttributeChecksum}.
+   *
+   * @param checksumEnabled  Status of checksums enabled for this table type
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeChecksum(ChecksumEnabled checksumEnabled, SqlParserPos pos) {
+    super(pos);
+    this.checksumEnabled = checksumEnabled;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    writer.keyword("CHECKSUM");
+    writer.sep("=");
+    switch (checksumEnabled) {
+    case DEFAULT:
+      writer.keyword("DEFAULT");
+      break;
+    case ON:
+      writer.keyword("ON");
+      break;
+    case OFF:
+      writer.keyword("OFF");
+      break;
+    }
+  }
+
+  public enum ChecksumEnabled {
+    /**
+     * The current checksum level setting specified for this table type.
+     */
+    DEFAULT,
+
+    /**
+     * Checksums are enabled for this table type.
+     */
+    ON,
+
+    /**
+     * Checksums are disabled for this table type.
+     */
+    OFF,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeDataBlockSize.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeDataBlockSize.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeDataBlockSize</code> is a CREATE TABLE option
+ * for the DATABLOCKSIZE attribute.
+ */
+public class SqlCreateAttributeDataBlockSize extends SqlCreateAttribute {
+
+  private final DataBlockModifier modifier;
+  private final DataBlockUnitSize unitSize;
+  private final SqlLiteral dataBlockSize;
+
+  /**
+   * Creates a {@code SqlCreateAttributeDataBlockSize}.
+   *
+   * @param modifier  Data block size modifier, may be null
+   * @param unitSize  Unit size of a data block size value
+   * @param dataBlockSize  Size of data block, numeric value
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeDataBlockSize(DataBlockModifier modifier,
+      DataBlockUnitSize unitSize, SqlLiteral dataBlockSize, SqlParserPos pos) {
+    super(pos);
+    this.modifier = modifier;
+    this.unitSize = unitSize;
+    this.dataBlockSize = dataBlockSize;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    if (modifier != null) {
+      switch (modifier) {
+      case DEFAULT:
+        writer.keyword("DEFAULT");
+        break;
+      case MINIMUM:
+        writer.keyword("MINIMUM");
+        break;
+      case MAXIMUM:
+        writer.keyword("MAXIMUM");
+        break;
+      }
+      writer.keyword("DATABLOCKSIZE");
+    } else {
+      writer.keyword("DATABLOCKSIZE");
+      writer.sep("=");
+      dataBlockSize.unparse(writer, 0, 0);
+      switch (unitSize) {
+      case BYTES:
+        writer.keyword("BYTES");
+        break;
+      case KILOBYTES:
+        writer.keyword("KILOBYTES");
+        break;
+      }
+    }
+  }
+
+  public enum DataBlockModifier {
+    /**
+     * The default data block size.
+     */
+    DEFAULT,
+
+    /**
+     * The minimum data block size for this table.
+     */
+    MINIMUM,
+
+    /**
+     * The maximum data block size for this table.
+     */
+    MAXIMUM,
+  }
+
+  public enum DataBlockUnitSize {
+    /**
+     * The data block size value is in bytes. Defaults to bytes if no unit size is specified.
+     */
+    BYTES,
+
+    /**
+     * The data block size value is in kilobytes.
+     */
+    KILOBYTES,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeFallback.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeFallback.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeFallback</code> is a CREATE TABLE option
+ * for the FALLBACK keyword.
+ */
+public class SqlCreateAttributeFallback extends SqlCreateAttribute {
+
+  private final boolean no;
+  private final boolean protection;
+
+  /**
+   * Creates a {@code SqlCreateAttributeFallback}.
+   *
+   * @param no  Optional NO keyword
+   * @param protection Optional PROTECTION keyword
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeFallback(boolean no, boolean protection, SqlParserPos pos) {
+    super(pos);
+    this.no = no;
+    this.protection = protection;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (no) {
+      writer.keyword("NO");
+    }
+    writer.keyword("FALLBACK");
+    if (protection) {
+      writer.keyword("PROTECTION");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeFreeSpace.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeFreeSpace.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeFreeSpace</code> is a CREATE TABLE option
+ * for the FREESPACE attribute.
+ */
+public class SqlCreateAttributeFreeSpace extends SqlCreateAttribute {
+
+  private final int freeSpaceValue;
+  private final boolean percent;
+
+  /**
+   * Creates a {@code SqlCreateAttributeFreeSpace}.
+   *
+   * @param freeSpaceValue  The percentage of free space to reserve during loading operations
+   * @param percent  Optional keyword PERCENT
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeFreeSpace(int freeSpaceValue, boolean percent, SqlParserPos pos) {
+    super(pos);
+    this.freeSpaceValue = freeSpaceValue;
+    this.percent = percent;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    writer.keyword("FREESPACE");
+    writer.sep("=");
+    writer.print(freeSpaceValue);
+    writer.print(" ");
+    if (percent) {
+      writer.keyword("PERCENT");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeIsolatedLoading.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeIsolatedLoading.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeIsolatedLoading</code> is a CREATE TABLE option
+ * for the WITH ISOLATED LOADING attribute.
+ */
+public class SqlCreateAttributeIsolatedLoading extends SqlCreateAttribute {
+
+  private final boolean nonLoadIsolated;
+  private final boolean concurrent;
+  private final OperationLevel operationLevel;
+
+  /**
+   * Creates a {@code SqlCreateAttributeIsolatedLoading}.
+   *
+   * @param nonLoadIsolated  Defines table as non-load isolated
+   * @param concurrent  Allows concurrent read operations while table is being modified
+   * @param operationLevel  Specifies types of operations allowed to be concurrent, may be null
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeIsolatedLoading(boolean nonLoadIsolated, boolean concurrent,
+      OperationLevel operationLevel, SqlParserPos pos) {
+    super(pos);
+    this.nonLoadIsolated = nonLoadIsolated;
+    this.concurrent = concurrent;
+    this.operationLevel = operationLevel;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    writer.keyword("WITH");
+    if (nonLoadIsolated) {
+      writer.keyword("NO");
+    }
+    if (concurrent) {
+      writer.keyword("CONCURRENT");
+    }
+    writer.keyword("ISOLATED LOADING");
+    if (operationLevel != null) {
+      writer.keyword("FOR");
+      switch (operationLevel) {
+      case ALL:
+        writer.keyword("ALL");
+        break;
+      case INSERT:
+        writer.keyword("INSERT");
+        break;
+      case NONE:
+        writer.keyword("NONE");
+        break;
+      }
+    }
+  }
+
+  public enum OperationLevel {
+    /**
+     * All operations can be concurrent load isolated.
+     */
+    ALL,
+
+    /**
+     * Only insert operations can be concurrent load isolated.
+     */
+    INSERT,
+
+    /**
+     * No concurrent load operations are allowed.
+     */
+    NONE,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeJournal.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeJournal.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeJournal</code> is a CREATE TABLE option
+ * for the JOURNAL attribute.
+ */
+public class SqlCreateAttributeJournal extends SqlCreateAttribute {
+
+  private final JournalType journalType;
+  private final JournalModifier journalModifier;
+
+  /**
+   * Creates a {@code SqlCreateAttributeJournal}.
+   *
+   * @param journalType  Type of journal image to be maintained
+   * @param journalModifier  Journal image modifier
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeJournal(JournalType journalType,
+      JournalModifier journalModifier,
+      SqlParserPos pos) {
+    super(pos);
+    this.journalType = journalType;
+    this.journalModifier = journalModifier;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    switch (journalModifier) {
+    case NO:
+      writer.keyword("NO");
+      break;
+    case DUAL:
+      writer.keyword("DUAL");
+      break;
+    case LOCAL:
+      writer.keyword("LOCAL");
+      break;
+    case NOT_LOCAL:
+      writer.keyword("NOT");
+      writer.keyword("LOCAL");
+      break;
+    default:
+    }
+    switch (journalType) {
+    case BEFORE:
+      writer.keyword("BEFORE");
+      break;
+    case AFTER:
+      writer.keyword("AFTER");
+      break;
+    default:
+    }
+    writer.keyword("JOURNAL");
+  }
+
+  public enum JournalType {
+    /**
+     * Maintains both types of journal images.
+     */
+    UNSPECIFIED,
+
+    /**
+     * Maintains a before change image.
+     */
+    BEFORE,
+
+    /**
+     * Maintains an after change image.
+     */
+    AFTER,
+  }
+
+  public enum JournalModifier {
+    /**
+     * No modifiers specified.
+     */
+    UNSPECIFIED,
+
+    /**
+     * A journal image is not maintained.
+     */
+    NO,
+
+    /**
+     * Two journal images are maintained.
+     */
+    DUAL,
+
+    /**
+     * Single after-image journal rows are written locally.
+     */
+    LOCAL,
+
+    /**
+     * Single after-image journal rows are not written locally.
+     */
+    NOT_LOCAL,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeJournalTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeJournalTable.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeJournalTable</code> is a CREATE TABLE option
+ * for the WITH JOURNAL TABLE attribute.
+ */
+public class SqlCreateAttributeJournalTable extends SqlCreateAttribute {
+
+  private final SqlIdentifier tableName;
+
+  /**
+   * Creates a {@code SqlCreateAttributeJournalTable}.
+   *
+   * @param tableName  Name of the permanent journal table to be used
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeJournalTable(SqlIdentifier tableName, SqlParserPos pos) {
+    super(pos);
+    this.tableName = tableName;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    writer.keyword("WITH");
+    writer.keyword("JOURNAL");
+    writer.keyword("TABLE");
+    writer.sep("=");
+    tableName.unparse(writer, 0, 0);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeLog.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeLog.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeLog</code> is a CREATE TABLE option
+ * for the LOG attribute.
+ */
+public class SqlCreateAttributeLog extends SqlCreateAttribute {
+
+  private final boolean loggingEnabled;
+
+  /**
+   * Creates a {@code SqlCreateAttributeLog}.
+   *
+   * @param loggingEnabled  Transient journal logging is enabled
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeLog(boolean loggingEnabled, SqlParserPos pos) {
+    super(pos);
+    this.loggingEnabled = loggingEnabled;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (!loggingEnabled) {
+      writer.keyword("NO");
+    }
+    writer.keyword("LOG");
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeMap.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeMap.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeMap</code> is a CREATE TABLE option
+ * for the MAP attribute.
+ */
+public class SqlCreateAttributeMap extends SqlCreateAttribute {
+
+  private final SqlIdentifier mapName;
+
+  /**
+   * Creates a {@code SqlCreateAttributeMap}.
+   *
+   * @param mapName  Name of an existing contiguous map
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeMap(SqlIdentifier mapName, SqlParserPos pos) {
+    super(pos);
+    this.mapName = mapName;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    writer.keyword("MAP");
+    writer.sep("=");
+    mapName.unparse(writer, 0, 0);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeMergeBlockRatio.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateAttributeMergeBlockRatio.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlCreateAttributeMergeBlockRatio</code> is a CREATE TABLE option
+ * for the MERGEBLOCKRATIO attribute.
+ */
+public class SqlCreateAttributeMergeBlockRatio extends SqlCreateAttribute {
+
+  private final MergeBlockRatioModifier modifier;
+  private final int ratio;
+  private final boolean percent;
+
+  /**
+   * Creates a {@code SqlCreateAttributeMergeBlockRatio}.
+   *
+   * @param modifier  Type of merge block ratio to be used
+   * @param ratio  The merge block ratio
+   * @param percent  Indicates that the integer value is a percentage
+   * @param pos  Parser position, must not be null
+   */
+  public SqlCreateAttributeMergeBlockRatio(MergeBlockRatioModifier modifier,
+      int ratio, boolean percent, SqlParserPos pos) {
+    super(pos);
+    this.modifier = modifier;
+    this.ratio = ratio;
+    this.percent = percent;
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec, final int rightPrec) {
+    switch (modifier) {
+    case UNSPECIFIED:
+      writer.keyword("MERGEBLOCKRATIO");
+      writer.sep("=");
+      writer.print(ratio);
+      writer.print(" ");
+      if (percent) {
+        writer.keyword("PERCENT");
+      }
+      break;
+    case DEFAULT:
+      writer.keyword("DEFAULT");
+      writer.keyword("MERGEBLOCKRATIO");
+      break;
+    case NO:
+      writer.keyword("NO");
+      writer.keyword("MERGEBLOCKRATIO");
+      break;
+    }
+  }
+
+  public enum MergeBlockRatioModifier {
+    /**
+     * Uses value specified by integer as merge block ratio.
+     */
+    UNSPECIFIED,
+
+    /**
+     * Uses the default value for merge block ratio.
+     */
+    DEFAULT,
+
+    /**
+     * Does not merge small data blocks.
+     */
+    NO,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateForeignSchema.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateForeignSchema.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.avatica.AvaticaUtils;
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.model.JsonSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+import com.google.common.base.Preconditions;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code CREATE FOREIGN SCHEMA} statement.
+ */
+public class SqlCreateForeignSchema extends SqlCreate
+    implements SqlExecutableStatement {
+  private final SqlIdentifier name;
+  private final SqlNode type;
+  private final SqlNode library;
+  private final SqlNodeList optionList;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE FOREIGN SCHEMA",
+          SqlKind.CREATE_FOREIGN_SCHEMA);
+
+  /** Creates a SqlCreateForeignSchema. */
+  SqlCreateForeignSchema(SqlParserPos pos, boolean replace, boolean ifNotExists,
+      SqlIdentifier name, SqlNode type, SqlNode library,
+      SqlNodeList optionList) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+    this.type = type;
+    this.library = library;
+    Preconditions.checkArgument((type == null) != (library == null),
+        "of type and library, exactly one must be specified");
+    this.optionList = optionList; // may be null
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, type, library, optionList);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (getReplace()) {
+      writer.keyword("CREATE OR REPLACE");
+    } else {
+      writer.keyword("CREATE");
+    }
+    writer.keyword("FOREIGN SCHEMA");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+    if (library != null) {
+      writer.keyword("LIBRARY");
+      library.unparse(writer, 0, 0);
+    }
+    if (type != null) {
+      writer.keyword("TYPE");
+      type.unparse(writer, 0, 0);
+    }
+    if (optionList != null) {
+      writer.keyword("OPTIONS");
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      int i = 0;
+      for (Pair<SqlIdentifier, SqlNode> c : options(optionList)) {
+        if (i++ > 0) {
+          writer.sep(",");
+        }
+        c.left.unparse(writer, 0, 0);
+        c.right.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    final SchemaPlus subSchema0 = pair.left.plus().getSubSchema(pair.right);
+    if (subSchema0 != null) {
+      if (!getReplace() && !ifNotExists) {
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.schemaExists(pair.right));
+      }
+    }
+    final Schema subSchema;
+    final String libraryName;
+    if (type != null) {
+      Preconditions.checkArgument(library == null);
+      final String typeName = (String) value(this.type);
+      final JsonSchema.Type type =
+          Util.enumVal(JsonSchema.Type.class,
+              typeName.toUpperCase(Locale.ROOT));
+      if (type != null) {
+        switch (type) {
+        case JDBC:
+          libraryName = JdbcSchema.Factory.class.getName();
+          break;
+        default:
+          libraryName = null;
+        }
+      } else {
+        libraryName = null;
+      }
+      if (libraryName == null) {
+        throw SqlUtil.newContextException(this.type.getParserPosition(),
+            RESOURCE.schemaInvalidType(typeName,
+                Arrays.toString(JsonSchema.Type.values())));
+      }
+    } else {
+      Preconditions.checkArgument(library != null);
+      libraryName = (String) value(library);
+    }
+    final SchemaFactory schemaFactory =
+        AvaticaUtils.instantiatePlugin(SchemaFactory.class, libraryName);
+    final Map<String, Object> operandMap = new LinkedHashMap<>();
+    for (Pair<SqlIdentifier, SqlNode> option : options(optionList)) {
+      operandMap.put(option.left.getSimple(), value(option.right));
+    }
+    subSchema =
+        schemaFactory.create(pair.left.plus(), pair.right, operandMap);
+    pair.left.add(pair.right, subSchema);
+  }
+
+  /** Returns the value of a literal, converting
+   * {@link NlsString} into String. */
+  private static Comparable value(SqlNode node) {
+    final Comparable v = SqlLiteral.value(node);
+    return v instanceof NlsString ? ((NlsString) v).getValue() : v;
+  }
+
+  private static List<Pair<SqlIdentifier, SqlNode>> options(
+      final SqlNodeList optionList) {
+    return new AbstractList<Pair<SqlIdentifier, SqlNode>>() {
+      public Pair<SqlIdentifier, SqlNode> get(int index) {
+        return Pair.of((SqlIdentifier) optionList.get(index * 2),
+            optionList.get(index * 2 + 1));
+      }
+
+      public int size() {
+        return optionList.size() / 2;
+      }
+    };
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code CREATE FUNCTION} statement.
+ */
+public class SqlCreateFunction extends SqlCreate
+    implements SqlExecutableStatement {
+  public final SqlIdentifier name;
+  private final SqlNode className;
+  private final SqlNodeList usingList;
+
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION);
+
+  /** Creates a SqlCreateFunction. */
+  public SqlCreateFunction(SqlParserPos pos, boolean replace,
+      boolean ifNotExists, SqlIdentifier name,
+      SqlNode className, SqlNodeList usingList) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+    this.className = className;
+    this.usingList = Objects.requireNonNull(usingList);
+    Preconditions.checkArgument(usingList.size() % 2 == 0);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec,
+      int rightPrec) {
+    writer.keyword(getReplace() ? "CREATE OR REPLACE" : "CREATE");
+    writer.keyword("FUNCTION");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, 0, 0);
+    writer.keyword("AS");
+    className.unparse(writer, 0, 0);
+    if (usingList.size() > 0) {
+      writer.keyword("USING");
+      final SqlWriter.Frame frame =
+          writer.startList(SqlWriter.FrameTypeEnum.SIMPLE);
+      for (Pair<SqlLiteral, SqlLiteral> using : pairs()) {
+        writer.sep(",");
+        using.left.unparse(writer, 0, 0); // FILE, URL or ARCHIVE
+        using.right.unparse(writer, 0, 0); // e.g. 'file:foo/bar.jar'
+      }
+      writer.endList(frame);
+    }
+  }
+
+  @Override public void execute(CalcitePrepare.Context context) {
+    throw new UnsupportedOperationException("CREATE FUNCTION is not supported yet.");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Pair<SqlLiteral, SqlLiteral>> pairs() {
+    return Util.pairs((List) usingList.getList());
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return Arrays.asList(name, className, usingList);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateFunctionSqlForm.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateFunctionSqlForm.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+public class SqlCreateFunctionSqlForm extends SqlCreate {
+  public final SqlIdentifier functionName;
+  public final SqlIdentifier specificFunctionName;
+  public final SqlNodeList fieldNames;
+  public final SqlNodeList fieldTypes;
+  public final SqlDataTypeSpec returnsDataType;
+  public final DeterministicType isDeterministic;
+  public final ReactToNullInputType canRunOnNullInput;
+  public final boolean hasSqlSecurityDefiner;
+  public final int typeInt;
+  public final SqlNode returnExpression;
+
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION);
+
+  /**
+   * Creates a SqlCreateFunctionSqlForm.
+   * @param pos position
+   * @param replace if "or replace" token occurred
+   * @param functionName the name of the function
+   * @param specificFunctionName an optional specific functionName
+   * @param fieldNames function parameter names
+   * @param fieldTypes function parameter types
+   * @param returnsDataType return type of the function
+   * @param isDeterministic if "deterministic" is specified
+   * @param canRunOnNullInput if "called on null input" or "returns null on null input"
+   *                          is specified
+   * @param hasSqlSecurityDefiner if "sql security definer" is specified
+   * @param typeInt integer value after inline type
+   * @param returnExpression the expression that is returned
+   */
+  public SqlCreateFunctionSqlForm(final SqlParserPos pos, final boolean replace,
+      final SqlIdentifier functionName,
+      final SqlIdentifier specificFunctionName, final SqlNodeList fieldNames,
+      final SqlNodeList fieldTypes,
+      final SqlDataTypeSpec returnsDataType, final DeterministicType isDeterministic,
+      final ReactToNullInputType canRunOnNullInput, final boolean hasSqlSecurityDefiner,
+      final int typeInt, final SqlNode returnExpression) {
+
+    super(OPERATOR, pos, replace, false);
+    this.functionName = functionName;
+    this.fieldNames = fieldNames;
+    this.fieldTypes = fieldTypes;
+    this.specificFunctionName = specificFunctionName;
+    this.returnsDataType = returnsDataType;
+    this.isDeterministic = isDeterministic;
+    this.canRunOnNullInput = canRunOnNullInput;
+    this.hasSqlSecurityDefiner = hasSqlSecurityDefiner;
+    this.typeInt = typeInt;
+    this.returnExpression = returnExpression;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(functionName, fieldNames, fieldTypes,
+        specificFunctionName, returnsDataType, returnExpression);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE FUNCTION");
+    functionName.unparse(writer, 0,  0);
+
+    SqlWriter.Frame frame = writer.startList("(", ")");
+    for (int i = 0; i < fieldNames.size(); i++) {
+      writer.sep(",", false);
+      fieldNames.get(i).unparse(writer, 0, 0);
+      fieldTypes.get(i).unparse(writer, 0, 0);
+    }
+    writer.endList(frame);
+    writer.keyword("RETURNS");
+    returnsDataType.unparse(writer, 0, 0);
+
+    writer.keyword("LANGUAGE SQL");
+    switch (isDeterministic) {
+    case UNSPECIFIED:
+      break;
+    case DETERMINISTIC:
+      writer.keyword("DETERMINISTIC");
+      break;
+    case NOTDETERMINISTIC:
+      writer.keyword("NOT DETERMINISTIC");
+      break;
+    }
+
+    switch (canRunOnNullInput) {
+    case UNSPECIFIED:
+      break;
+    case RETURNSNULL:
+      writer.keyword("RETURNS NULL ON NULL INPUT");
+      break;
+    case CALLED:
+      writer.keyword("CALLED ON NULL INPUT");
+      break;
+    }
+
+    if (specificFunctionName != null) {
+      writer.keyword("SPECIFIC");
+      specificFunctionName.unparse(writer, 0, 0);
+    }
+
+    if (hasSqlSecurityDefiner) {
+      writer.keyword("SQL SECURITY DEFINER");
+    }
+
+    writer.keyword("COLLATION INVOKER INLINE TYPE");
+    writer.print(typeInt + " ");
+    writer.keyword("RETURN");
+    returnExpression.unparse(writer, 0, 0);
+  }
+
+  public enum DeterministicType {
+    /**
+     * Not Specified.
+     */
+    UNSPECIFIED,
+
+    /**
+     * Explicitly stated deterministic.
+     */
+    DETERMINISTIC,
+
+    /**
+     * Explicitly stated not deterministic.
+     */
+    NOTDETERMINISTIC,
+  }
+
+  public enum ReactToNullInputType {
+    /**
+     * Not Specified.
+     */
+    UNSPECIFIED,
+
+    /**
+     * Explicitly stated return null.
+     */
+    RETURNSNULL,
+
+    /**
+     * Explicitly stated allows call.
+     */
+    CALLED,
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateMaterializedView.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateMaterializedView.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.materialize.MaterializationKey;
+import org.apache.calcite.materialize.MaterializationService;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.calcite.schema.impl.ViewTableMacro;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code CREATE MATERIALIZED VIEW} statement.
+ */
+public class SqlCreateMaterializedView extends SqlCreate
+    implements SqlExecutableStatement {
+  private final SqlIdentifier name;
+  private final SqlNodeList columnList;
+  private final SqlNode query;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE MATERIALIZED VIEW",
+          SqlKind.CREATE_MATERIALIZED_VIEW);
+
+  /** Creates a SqlCreateView. */
+  SqlCreateMaterializedView(SqlParserPos pos, boolean replace,
+      boolean ifNotExists, SqlIdentifier name, SqlNodeList columnList,
+      SqlNode query) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+    this.columnList = columnList; // may be null
+    this.query = Objects.requireNonNull(query);
+  }
+
+  public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, columnList, query);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE");
+    writer.keyword("MATERIALIZED VIEW");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+    if (columnList != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode c : columnList) {
+        writer.sep(",");
+        c.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    writer.keyword("AS");
+    writer.newlineAndIndent();
+    query.unparse(writer, 0, 0);
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    if (pair.left.plus().getTable(pair.right) != null) {
+      // Materialized view exists.
+      if (!ifNotExists) {
+        // They did not specify IF NOT EXISTS, so give error.
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.tableExists(pair.right));
+      }
+      return;
+    }
+    final SqlNode q = SqlDdlNodes.renameColumns(columnList, query);
+    final String sql = q.toSqlString(CalciteSqlDialect.DEFAULT).getSql();
+    final List<String> schemaPath = pair.left.path(null);
+    final ViewTableMacro viewTableMacro =
+        ViewTable.viewMacro(pair.left.plus(), sql, schemaPath,
+            context.getObjectPath(), false);
+    final TranslatableTable x = viewTableMacro.apply(ImmutableList.of());
+    final RelDataType rowType = x.getRowType(context.getTypeFactory());
+
+    // Table does not exist. Create it.
+    final MaterializedViewTable table =
+        new MaterializedViewTable(pair.right, RelDataTypeImpl.proto(rowType));
+    pair.left.add(pair.right, table);
+    SqlDdlNodes.populate(name, query, context);
+    table.key =
+        MaterializationService.instance().defineMaterialization(pair.left, null,
+            sql, schemaPath, pair.right, true, true);
+  }
+
+  /** A table that implements a materialized view. */
+  private static class MaterializedViewTable
+      extends SqlCreateTable.MutableArrayTable {
+    /** The key with which this was stored in the materialization service,
+     * or null if not (yet) materialized. */
+    MaterializationKey key;
+
+    MaterializedViewTable(String name, RelProtoDataType protoRowType) {
+      super(name, protoRowType, protoRowType,
+          NullInitializerExpressionFactory.INSTANCE);
+    }
+
+    @Override public Schema.TableType getJdbcTableType() {
+      return Schema.TableType.MATERIALIZED_VIEW;
+    }
+
+    @Override public <C> C unwrap(Class<C> aClass) {
+      if (MaterializationKey.class.isAssignableFrom(aClass)
+          && aClass.isInstance(key)) {
+        return aClass.cast(key);
+      }
+      return super.unwrap(aClass);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateSchema.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateSchema.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code CREATE SCHEMA} statement.
+ */
+public class SqlCreateSchema extends SqlCreate
+    implements SqlExecutableStatement {
+  private final SqlIdentifier name;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE SCHEMA", SqlKind.CREATE_SCHEMA);
+
+  /** Creates a SqlCreateSchema. */
+  SqlCreateSchema(SqlParserPos pos, boolean replace, boolean ifNotExists,
+      SqlIdentifier name) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (getReplace()) {
+      writer.keyword("CREATE OR REPLACE");
+    } else {
+      writer.keyword("CREATE");
+    }
+    writer.keyword("SCHEMA");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    final SchemaPlus subSchema0 = pair.left.plus().getSubSchema(pair.right);
+    if (subSchema0 != null) {
+      if (!getReplace() && !ifNotExists) {
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.schemaExists(pair.right));
+      }
+    }
+    final Schema subSchema = new AbstractSchema();
+    pair.left.add(pair.right, subSchema);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateTable.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.schema.ModifiableTable;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.Wrapper;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.schema.impl.AbstractTableQueryable;
+import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.calcite.schema.impl.ViewTableMacro;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql2rel.InitializerContext;
+import org.apache.calcite.sql2rel.InitializerExpressionFactory;
+import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code CREATE TABLE} statement.
+ */
+public class SqlCreateTable extends SqlCreate
+    implements SqlExecutableStatement {
+  private final SqlIdentifier name;
+  private final SqlNodeList columnList;
+  private final SqlNode query;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
+
+  /** Creates a SqlCreateTable. */
+  SqlCreateTable(SqlParserPos pos, boolean replace, boolean ifNotExists,
+      SqlIdentifier name, SqlNodeList columnList, SqlNode query) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+    this.columnList = columnList; // may be null
+    this.query = query; // for "CREATE TABLE ... AS query"; may be null
+  }
+
+  public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, columnList, query);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE");
+    writer.keyword("TABLE");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+    if (columnList != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode c : columnList) {
+        writer.sep(",");
+        c.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    if (query != null) {
+      writer.keyword("AS");
+      writer.newlineAndIndent();
+      query.unparse(writer, 0, 0);
+    }
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    final JavaTypeFactory typeFactory = context.getTypeFactory();
+    final RelDataType queryRowType;
+    if (query != null) {
+      // A bit of a hack: pretend it's a view, to get its row type
+      final String sql = query.toSqlString(CalciteSqlDialect.DEFAULT).getSql();
+      final ViewTableMacro viewTableMacro =
+          ViewTable.viewMacro(pair.left.plus(), sql, pair.left.path(null),
+              context.getObjectPath(), false);
+      final TranslatableTable x = viewTableMacro.apply(ImmutableList.of());
+      queryRowType = x.getRowType(typeFactory);
+
+      if (columnList != null
+          && queryRowType.getFieldCount() != columnList.size()) {
+        throw SqlUtil.newContextException(columnList.getParserPosition(),
+            RESOURCE.columnCountMismatch());
+      }
+    } else {
+      queryRowType = null;
+    }
+    final List<SqlNode> columnList;
+    if (this.columnList != null) {
+      columnList = this.columnList.getList();
+    } else {
+      if (queryRowType == null) {
+        // "CREATE TABLE t" is invalid; because there is no "AS query" we need
+        // a list of column names and types, "CREATE TABLE t (INT c)".
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.createTableRequiresColumnList());
+      }
+      columnList = new ArrayList<>();
+      for (String name : queryRowType.getFieldNames()) {
+        columnList.add(new SqlIdentifier(name, SqlParserPos.ZERO));
+      }
+    }
+    final ImmutableList.Builder<ColumnDef> b = ImmutableList.builder();
+    final RelDataTypeFactory.Builder builder = typeFactory.builder();
+    final RelDataTypeFactory.Builder storedBuilder = typeFactory.builder();
+    // REVIEW 2019-08-19 Danny Chan: Should we implement the
+    // #validate(SqlValidator) to get the SqlValidator instance?
+    final SqlValidator validator = SqlDdlNodes.validator(context, true);
+    for (Ord<SqlNode> c : Ord.zip(columnList)) {
+      if (c.e instanceof SqlColumnDeclaration) {
+        final SqlColumnDeclaration d = (SqlColumnDeclaration) c.e;
+        final RelDataType type = d.dataType.deriveType(validator, true);
+        builder.add(d.name.getSimple(), type);
+        if (d.strategy != ColumnStrategy.VIRTUAL) {
+          storedBuilder.add(d.name.getSimple(), type);
+        }
+        b.add(ColumnDef.of(d.expression, type, d.strategy));
+      } else if (c.e instanceof SqlIdentifier) {
+        final SqlIdentifier id = (SqlIdentifier) c.e;
+        if (queryRowType == null) {
+          throw SqlUtil.newContextException(id.getParserPosition(),
+              RESOURCE.createTableRequiresColumnTypes(id.getSimple()));
+        }
+        final RelDataTypeField f = queryRowType.getFieldList().get(c.i);
+        final ColumnStrategy strategy = f.getType().isNullable()
+            ? ColumnStrategy.NULLABLE
+            : ColumnStrategy.NOT_NULLABLE;
+        b.add(ColumnDef.of(c.e, f.getType(), strategy));
+        builder.add(id.getSimple(), f.getType());
+        storedBuilder.add(id.getSimple(), f.getType());
+      } else {
+        throw new AssertionError(c.e.getClass());
+      }
+    }
+    final RelDataType rowType = builder.build();
+    final RelDataType storedRowType = storedBuilder.build();
+    final List<ColumnDef> columns = b.build();
+    final InitializerExpressionFactory ief =
+        new NullInitializerExpressionFactory() {
+          @Override public ColumnStrategy generationStrategy(RelOptTable table,
+              int iColumn) {
+            return columns.get(iColumn).strategy;
+          }
+
+          @Override public RexNode newColumnDefaultValue(RelOptTable table,
+              int iColumn, InitializerContext context) {
+            final ColumnDef c = columns.get(iColumn);
+            if (c.expr != null) {
+              // REVIEW Danny 2019-10-09: Should we support validation for DDL nodes?
+              final SqlNode validated = context.validateExpression(storedRowType, c.expr);
+              // The explicit specified type should have the same nullability
+              // with the column expression inferred type,
+              // actually they should be exactly the same.
+              return context.convertExpression(validated);
+            }
+            return super.newColumnDefaultValue(table, iColumn, context);
+          }
+        };
+    if (pair.left.plus().getTable(pair.right) != null) {
+      // Table exists.
+      if (!ifNotExists) {
+        // They did not specify IF NOT EXISTS, so give error.
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.tableExists(pair.right));
+      }
+      return;
+    }
+    // Table does not exist. Create it.
+    pair.left.add(pair.right,
+        new MutableArrayTable(pair.right,
+            RelDataTypeImpl.proto(storedRowType),
+            RelDataTypeImpl.proto(rowType), ief));
+    if (query != null) {
+      SqlDdlNodes.populate(name, query, context);
+    }
+  }
+
+  /** Column definition. */
+  private static class ColumnDef {
+    final SqlNode expr;
+    final RelDataType type;
+    final ColumnStrategy strategy;
+
+    private ColumnDef(SqlNode expr, RelDataType type,
+        ColumnStrategy strategy) {
+      this.expr = expr;
+      this.type = type;
+      this.strategy = Objects.requireNonNull(strategy);
+      Preconditions.checkArgument(
+          strategy == ColumnStrategy.NULLABLE
+              || strategy == ColumnStrategy.NOT_NULLABLE
+              || expr != null);
+    }
+
+    static ColumnDef of(SqlNode expr, RelDataType type,
+        ColumnStrategy strategy) {
+      return new ColumnDef(expr, type, strategy);
+    }
+  }
+
+  /** Abstract base class for implementations of {@link ModifiableTable}. */
+  abstract static class AbstractModifiableTable
+      extends AbstractTable implements ModifiableTable {
+    AbstractModifiableTable(String tableName) {
+      super();
+    }
+
+    public TableModify toModificationRel(
+        RelOptCluster cluster,
+        RelOptTable table,
+        Prepare.CatalogReader catalogReader,
+        RelNode child,
+        TableModify.Operation operation,
+        List<String> updateColumnList,
+        List<RexNode> sourceExpressionList,
+        boolean flattened) {
+      return LogicalTableModify.create(table, catalogReader, child, operation,
+          updateColumnList, sourceExpressionList, flattened);
+    }
+  }
+
+  /** Table backed by a Java list. */
+  static class MutableArrayTable extends AbstractModifiableTable
+      implements Wrapper {
+    final List rows = new ArrayList();
+    private final RelProtoDataType protoStoredRowType;
+    private final RelProtoDataType protoRowType;
+    private final InitializerExpressionFactory initializerExpressionFactory;
+
+    /** Creates a MutableArrayTable.
+     *
+     * @param name Name of table within its schema
+     * @param protoStoredRowType Prototype of row type of stored columns (all
+     *     columns except virtual columns)
+     * @param protoRowType Prototype of row type (all columns)
+     * @param initializerExpressionFactory How columns are populated
+     */
+    MutableArrayTable(String name, RelProtoDataType protoStoredRowType,
+        RelProtoDataType protoRowType,
+        InitializerExpressionFactory initializerExpressionFactory) {
+      super(name);
+      this.protoStoredRowType = Objects.requireNonNull(protoStoredRowType);
+      this.protoRowType = Objects.requireNonNull(protoRowType);
+      this.initializerExpressionFactory =
+          Objects.requireNonNull(initializerExpressionFactory);
+    }
+
+    public Collection getModifiableCollection() {
+      return rows;
+    }
+
+    public <T> Queryable<T> asQueryable(QueryProvider queryProvider,
+        SchemaPlus schema, String tableName) {
+      return new AbstractTableQueryable<T>(queryProvider, schema, this,
+          tableName) {
+        public Enumerator<T> enumerator() {
+          //noinspection unchecked
+          return (Enumerator<T>) Linq4j.enumerator(rows);
+        }
+      };
+    }
+
+    public Type getElementType() {
+      return Object[].class;
+    }
+
+    public Expression getExpression(SchemaPlus schema, String tableName,
+        Class clazz) {
+      return Schemas.tableExpression(schema, getElementType(),
+          tableName, clazz);
+    }
+
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+      return protoRowType.apply(typeFactory);
+    }
+
+    @Override public <C> C unwrap(Class<C> aClass) {
+      if (aClass.isInstance(initializerExpressionFactory)) {
+        return aClass.cast(initializerExpressionFactory);
+      }
+      return super.unwrap(aClass);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateTableDialect1.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateTableDialect1.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code CREATE TABLE} statement.
+ */
+public class SqlCreateTableDialect1 extends SqlCreate
+    implements SqlExecutableStatement {
+  public final SqlIdentifier name;
+  public final SetType setType;
+  public final Volatility volatility;
+  public final List<SqlCreateAttribute> tableAttributes;
+  public final SqlNodeList columnList;
+  public final SqlNode query;
+  public final WithDataType withData;
+  public final SqlPrimaryIndex primaryIndex;
+  public final OnCommitType onCommitType;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
+
+  /** Creates a SqlCreateTableDialect1. */
+  public SqlCreateTableDialect1(SqlParserPos pos, boolean replace, SetType setType, Volatility volatility,
+      boolean ifNotExists, SqlIdentifier name, SqlNodeList columnList, SqlNode query) {
+    this(pos, replace, setType, volatility, ifNotExists, name, /*tableAttributes=*/null,
+        columnList, query, WithDataType.UNSPECIFIED,
+        /*primaryIndex=*/ null, OnCommitType.UNSPECIFIED);
+  }
+
+  public SqlCreateTableDialect1(SqlParserPos pos, boolean replace, SetType setType, Volatility volatility,
+      boolean ifNotExists, SqlIdentifier name, SqlNodeList columnList, SqlNode query,
+      WithDataType withData, OnCommitType onCommitType) {
+    this(pos, replace, setType, volatility, ifNotExists, name, /*tableAttributes=*/null,
+        columnList, query, withData, /*primaryIndex=*/ null, onCommitType);
+  }
+
+  public SqlCreateTableDialect1(SqlParserPos pos, boolean replace, SetType setType, Volatility volatility,
+      boolean ifNotExists, SqlIdentifier name, List<SqlCreateAttribute> tableAttributes,
+      SqlNodeList columnList, SqlNode query,
+      WithDataType withData, OnCommitType onCommitType) {
+    this(pos, replace, setType, volatility, ifNotExists, name, tableAttributes,
+        columnList, query, withData, /*primaryIndex=*/ null, onCommitType);
+  }
+
+  public SqlCreateTableDialect1(SqlParserPos pos, boolean replace, SetType setType, Volatility volatility,
+      boolean ifNotExists, SqlIdentifier name, List<SqlCreateAttribute> tableAttributes,
+      SqlNodeList columnList, SqlNode query,
+      WithDataType withData, SqlPrimaryIndex primaryIndex, OnCommitType onCommitType) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.name = Objects.requireNonNull(name);
+    this.setType = setType;
+    this.volatility = volatility;
+    this.tableAttributes = tableAttributes; // may be null
+    this.columnList = columnList; // may be null
+    this.query = query; // for "CREATE TABLE ... AS query"; may be null
+    this.withData = withData;
+    this.primaryIndex = primaryIndex;
+    this.onCommitType = onCommitType;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, columnList, query);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE");
+    switch (setType) {
+    case SET:
+      writer.keyword("SET");
+      break;
+    case MULTISET:
+      writer.keyword("MULTISET");
+      break;
+    default:
+      break;
+    }
+    switch (volatility) {
+    case VOLATILE:
+      writer.keyword("VOLATILE");
+      break;
+    case TEMP:
+      writer.keyword("TEMP");
+      break;
+    default:
+      break;
+    }
+    writer.keyword("TABLE");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+    if (tableAttributes != null) {
+      SqlWriter.Frame frame = writer.startList("", "");
+      for (SqlCreateAttribute a : tableAttributes) {
+        writer.sep(",", true);
+        a.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    if (columnList != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode c : columnList) {
+        writer.sep(",");
+        c.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    if (query != null) {
+      writer.keyword("AS");
+      writer.newlineAndIndent();
+      query.unparse(writer, 0, 0);
+    }
+    switch (withData) {
+    case WITH_DATA:
+      writer.keyword("WITH DATA");
+      break;
+    case WITH_NO_DATA:
+      writer.keyword("WITH NO DATA");
+      break;
+    default:
+      break;
+    }
+    if (primaryIndex != null) {
+      primaryIndex.unparse(writer, leftPrec, rightPrec);
+    }
+    switch (onCommitType) {
+    case PRESERVE:
+      writer.keyword("ON COMMIT PRESERVE ROWS");
+      break;
+    case RELEASE:
+      writer.keyword("ON COMMIT RELEASE ROWS");
+      break;
+    default:
+      break;
+    }
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateType.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateType.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code CREATE TYPE} statement.
+ */
+public class SqlCreateType extends SqlCreate
+    implements SqlExecutableStatement {
+  private final SqlIdentifier name;
+  private final SqlNodeList attributeDefs;
+  private final SqlDataTypeSpec dataType;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE TYPE", SqlKind.CREATE_TYPE);
+
+  /** Creates a SqlCreateType. */
+  SqlCreateType(SqlParserPos pos, boolean replace, SqlIdentifier name,
+      SqlNodeList attributeDefs, SqlDataTypeSpec dataType) {
+    super(OPERATOR, pos, replace, false);
+    this.name = Objects.requireNonNull(name);
+    this.attributeDefs = attributeDefs; // may be null
+    this.dataType = dataType; // may be null
+  }
+
+  @Override public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    final SqlValidator validator = SqlDdlNodes.validator(context, false);
+    pair.left.add(pair.right, typeFactory -> {
+      if (dataType != null) {
+        return dataType.deriveType(validator);
+      } else {
+        final RelDataTypeFactory.Builder builder = typeFactory.builder();
+        for (SqlNode def : attributeDefs) {
+          final SqlAttributeDefinition attributeDef =
+              (SqlAttributeDefinition) def;
+          final SqlDataTypeSpec typeSpec = attributeDef.dataType;
+          final RelDataType type = typeSpec.deriveType(validator);
+          builder.add(attributeDef.name.getSimple(), type);
+        }
+        return builder.build();
+      }
+    });
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, attributeDefs);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (getReplace()) {
+      writer.keyword("CREATE OR REPLACE");
+    } else {
+      writer.keyword("CREATE");
+    }
+    writer.keyword("TYPE");
+    name.unparse(writer, leftPrec, rightPrec);
+    writer.keyword("AS");
+    if (attributeDefs != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode a : attributeDefs) {
+        writer.sep(",");
+        a.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    } else if (dataType != null) {
+      dataType.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateView.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateView.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.Function;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.calcite.schema.impl.ViewTableMacro;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code CREATE VIEW} statement.
+ */
+public class SqlCreateView extends SqlCreate
+    implements SqlExecutableStatement {
+  public final SqlIdentifier name;
+  public final SqlNodeList columnList;
+  public final SqlNode query;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE VIEW", SqlKind.CREATE_VIEW);
+
+  /** Creates a SqlCreateView. */
+  SqlCreateView(SqlParserPos pos, boolean replace, SqlIdentifier name,
+      SqlNodeList columnList, SqlNode query) {
+    super(OPERATOR, pos, replace, false);
+    this.name = Objects.requireNonNull(name);
+    this.columnList = columnList; // may be null
+    this.query = Objects.requireNonNull(query);
+  }
+
+  public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, columnList, query);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (getReplace()) {
+      writer.keyword("CREATE OR REPLACE");
+    } else {
+      writer.keyword("CREATE");
+    }
+    writer.keyword("VIEW");
+    name.unparse(writer, leftPrec, rightPrec);
+    if (columnList != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode c : columnList) {
+        writer.sep(",");
+        c.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    writer.keyword("AS");
+    writer.newlineAndIndent();
+    query.unparse(writer, 0, 0);
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    final SchemaPlus schemaPlus = pair.left.plus();
+    for (Function function : schemaPlus.getFunctions(pair.right)) {
+      if (function.getParameters().isEmpty()) {
+        if (!getReplace()) {
+          throw SqlUtil.newContextException(name.getParserPosition(),
+              RESOURCE.viewExists(pair.right));
+        }
+        pair.left.removeFunction(pair.right);
+      }
+    }
+    final SqlNode q = SqlDdlNodes.renameColumns(columnList, query);
+    final String sql = q.toSqlString(CalciteSqlDialect.DEFAULT).getSql();
+    final ViewTableMacro viewTableMacro =
+        ViewTable.viewMacro(schemaPlus, sql, pair.left.path(null),
+            context.getObjectPath(), false);
+    final TranslatableTable x = viewTableMacro.apply(ImmutableList.of());
+    Util.discard(x);
+    schemaPlus.add(pair.right, viewTableMacro);
+  }
+
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDateTimeAtLocal.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDateTimeAtLocal.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+public class SqlDateTimeAtLocal extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("AT LOCAL", SqlKind.OTHER);
+
+  private final SqlNode dateTimePrimary;
+
+  public SqlDateTimeAtLocal(SqlParserPos pos, SqlNode dateTimePrimary) {
+    super(pos);
+    this.dateTimePrimary = dateTimePrimary;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(dateTimePrimary);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    dateTimePrimary.unparse(writer, leftPrec, rightPrec);
+    writer.keyword("AT LOCAL");
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDateTimeAtTimeZone.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDateTimeAtTimeZone.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+public class SqlDateTimeAtTimeZone extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("AT TIME ZONE", SqlKind.OTHER);
+
+  private final SqlNode dateTimePrimary;
+  private final SqlIdentifier timeZoneValue;
+
+  public SqlDateTimeAtTimeZone(
+      SqlParserPos pos, SqlNode dateTimePrimary, SqlIdentifier timeZoneValue) {
+    super(pos);
+    this.dateTimePrimary = dateTimePrimary;
+    this.timeZoneValue = timeZoneValue;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(dateTimePrimary);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    dateTimePrimary.unparse(writer, leftPrec, rightPrec);
+    writer.keyword("AT TIME ZONE");
+    timeZoneValue.unparse(writer, leftPrec, rightPrec);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(final CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDdlNodes.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDdlNodes.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.ContextSqlValidator;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Planner;
+import org.apache.calcite.tools.RelConversionException;
+import org.apache.calcite.tools.ValidationException;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+
+import com.google.common.collect.ImmutableList;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Utilities concerning {@link SqlNode} for DDL.
+ */
+public class SqlDdlNodes {
+  private SqlDdlNodes() {}
+
+  /** Creates a CREATE SCHEMA. */
+  public static SqlCreateSchema createSchema(SqlParserPos pos, boolean replace,
+      boolean ifNotExists, SqlIdentifier name) {
+    return new SqlCreateSchema(pos, replace, ifNotExists, name);
+  }
+
+  /** Creates a CREATE FOREIGN SCHEMA. */
+  public static SqlCreateForeignSchema createForeignSchema(SqlParserPos pos,
+      boolean replace, boolean ifNotExists, SqlIdentifier name, SqlNode type,
+      SqlNode library, SqlNodeList optionList) {
+    return new SqlCreateForeignSchema(pos, replace, ifNotExists, name, type,
+        library, optionList);
+  }
+
+  /** Creates a CREATE TYPE. */
+  public static SqlCreateType createType(SqlParserPos pos, boolean replace,
+      SqlIdentifier name, SqlNodeList attributeList,
+      SqlDataTypeSpec dataTypeSpec) {
+    return new SqlCreateType(pos, replace, name, attributeList, dataTypeSpec);
+  }
+
+  /** Creates a CREATE TABLE. */
+  public static SqlCreateTable createTable(SqlParserPos pos, boolean replace,
+      boolean ifNotExists, SqlIdentifier name, SqlNodeList columnList,
+      SqlNode query) {
+    return new SqlCreateTable(pos, replace, ifNotExists, name, columnList,
+        query);
+  }
+
+  /** Creates a CREATE VIEW. */
+  public static SqlCreateView createView(SqlParserPos pos, boolean replace,
+      SqlIdentifier name, SqlNodeList columnList, SqlNode query) {
+    return new SqlCreateView(pos, replace, name, columnList, query);
+  }
+
+  /** Creates a CREATE MATERIALIZED VIEW. */
+  public static SqlCreateMaterializedView createMaterializedView(
+      SqlParserPos pos, boolean replace, boolean ifNotExists,
+      SqlIdentifier name, SqlNodeList columnList, SqlNode query) {
+    return new SqlCreateMaterializedView(pos, replace, ifNotExists, name,
+        columnList, query);
+  }
+
+  /** Creates a CREATE FUNCTION. */
+  public static SqlCreateFunction createFunction(
+      SqlParserPos pos, boolean replace, boolean ifNotExists,
+      SqlIdentifier name, SqlNode className, SqlNodeList usingList) {
+    return new SqlCreateFunction(pos, replace, ifNotExists, name,
+        className, usingList);
+  }
+
+  /** Creates a DROP [ FOREIGN ] SCHEMA. */
+  public static SqlDropSchema dropSchema(SqlParserPos pos, boolean foreign,
+      boolean ifExists, SqlIdentifier name) {
+    return new SqlDropSchema(pos, foreign, ifExists, name);
+  }
+
+  /** Creates a DROP TYPE. */
+  public static SqlDropType dropType(SqlParserPos pos, boolean ifExists,
+      SqlIdentifier name) {
+    return new SqlDropType(pos, ifExists, name);
+  }
+
+  /** Creates a DROP TABLE. */
+  public static SqlDropTable dropTable(SqlParserPos pos, boolean ifExists,
+      SqlIdentifier name) {
+    return new SqlDropTable(pos, ifExists, name);
+  }
+
+  /** Creates a DROP VIEW. */
+  public static SqlDrop dropView(SqlParserPos pos, boolean ifExists,
+      SqlIdentifier name) {
+    return new SqlDropView(pos, ifExists, name);
+  }
+
+  /** Creates a DROP MATERIALIZED VIEW. */
+  public static SqlDrop dropMaterializedView(SqlParserPos pos,
+      boolean ifExists, SqlIdentifier name) {
+    return new SqlDropMaterializedView(pos, ifExists, name);
+  }
+
+  /** Creates a DROP FUNCTION. */
+  public static SqlDrop dropFunction(SqlParserPos pos,
+      boolean ifExists, SqlIdentifier name) {
+    return new SqlDropFunction(pos, ifExists, name);
+  }
+
+  /** Creates a column declaration. */
+  public static SqlNode column(SqlParserPos pos, SqlIdentifier name,
+      SqlDataTypeSpec dataType, SqlNode expression, ColumnStrategy strategy) {
+    return new SqlColumnDeclaration(pos, name, dataType, expression, strategy);
+  }
+
+  /** Creates a attribute definition. */
+  public static SqlNode attribute(SqlParserPos pos, SqlIdentifier name,
+      SqlDataTypeSpec dataType, SqlNode expression, SqlCollation collation) {
+    return new SqlAttributeDefinition(pos, name, dataType, expression, collation);
+  }
+
+  /** Creates a CHECK constraint. */
+  public static SqlNode check(SqlParserPos pos, SqlIdentifier name,
+      SqlNode expression) {
+    return new SqlCheckConstraint(pos, name, expression);
+  }
+
+  /** Creates a UNIQUE constraint. */
+  public static SqlKeyConstraint unique(SqlParserPos pos, SqlIdentifier name,
+      SqlNodeList columnList) {
+    return new SqlKeyConstraint(pos, name, columnList);
+  }
+
+  /** Creates a PRIMARY KEY constraint. */
+  public static SqlKeyConstraint primary(SqlParserPos pos, SqlIdentifier name,
+      SqlNodeList columnList) {
+    return new SqlKeyConstraint(pos, name, columnList) {
+      @Override public SqlOperator getOperator() {
+        return PRIMARY;
+      }
+    };
+  }
+
+  /** Returns the schema in which to create an object. */
+  static Pair<CalciteSchema, String> schema(CalcitePrepare.Context context,
+      boolean mutable, SqlIdentifier id) {
+    final String name;
+    final List<String> path;
+    if (id.isSimple()) {
+      path = context.getDefaultSchemaPath();
+      name = id.getSimple();
+    } else {
+      path = Util.skipLast(id.names);
+      name = Util.last(id.names);
+    }
+    CalciteSchema schema = mutable ? context.getMutableRootSchema()
+        : context.getRootSchema();
+    for (String p : path) {
+      schema = schema.getSubSchema(p, true);
+    }
+    return Pair.of(schema, name);
+  }
+
+  /**
+   * Returns the SqlValidator with the given {@code context} schema
+   * and type factory.
+   * */
+  static SqlValidator validator(CalcitePrepare.Context context, boolean mutable) {
+    return new ContextSqlValidator(context, mutable);
+  }
+
+  /** Wraps a query to rename its columns. Used by CREATE VIEW and CREATE
+   * MATERIALIZED VIEW. */
+  static SqlNode renameColumns(SqlNodeList columnList, SqlNode query) {
+    if (columnList == null) {
+      return query;
+    }
+    final SqlParserPos p = query.getParserPosition();
+    final SqlNodeList selectList = SqlNodeList.SINGLETON_STAR;
+    final SqlCall from =
+        SqlStdOperatorTable.AS.createCall(p,
+            ImmutableList.<SqlNode>builder()
+                .add(query)
+                .add(new SqlIdentifier("_", p))
+                .addAll(columnList)
+                .build());
+    return new SqlSelect(p, null, selectList, from, null, null, null, null,
+        null, null, null, null);
+  }
+
+  /** Populates the table called {@code name} by executing {@code query}. */
+  protected static void populate(SqlIdentifier name, SqlNode query,
+      CalcitePrepare.Context context) {
+    // Generate, prepare and execute an "INSERT INTO table query" statement.
+    // (It's a bit inefficient that we convert from SqlNode to SQL and back
+    // again.)
+    final FrameworkConfig config = Frameworks.newConfigBuilder()
+        .defaultSchema(context.getRootSchema().plus())
+        .build();
+    final Planner planner = Frameworks.getPlanner(config);
+    try {
+      final StringBuilder buf = new StringBuilder();
+      final SqlWriterConfig writerConfig =
+          SqlPrettyWriter.config().withAlwaysUseParentheses(false);
+      final SqlPrettyWriter w = new SqlPrettyWriter(writerConfig, buf);
+      buf.append("INSERT INTO ");
+      name.unparse(w, 0, 0);
+      buf.append(' ');
+      query.unparse(w, 0, 0);
+      final String sql = buf.toString();
+      final SqlNode query1 = planner.parse(sql);
+      final SqlNode query2 = planner.validate(query1);
+      final RelRoot r = planner.rel(query2);
+      final PreparedStatement prepare = context.getRelRunner().prepare(r.rel);
+      int rowCount = prepare.executeUpdate();
+      Util.discard(rowCount);
+      prepare.close();
+    } catch (SqlParseException | ValidationException
+        | RelConversionException | SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** File type for CREATE FUNCTION. */
+  public enum FileType {
+    FILE,
+    JAR,
+    ARCHIVE
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Parse tree for {@code DROP FUNCTION} statement.
+ */
+public class SqlDropFunction extends SqlDropObject {
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP FUNCTION", SqlKind.DROP_FUNCTION);
+
+  /** Creates a SqlDropFunction. */
+  public SqlDropFunction(SqlParserPos pos, boolean ifExists,
+      SqlIdentifier name) {
+    super(OPERATOR, pos, ifExists, name);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropMaterializedView.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropMaterializedView.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.materialize.MaterializationKey;
+import org.apache.calcite.materialize.MaterializationService;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.Wrapper;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.Pair;
+
+/**
+ * Parse tree for {@code DROP MATERIALIZED VIEW} statement.
+ */
+public class SqlDropMaterializedView extends SqlDropObject {
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP MATERIALIZED VIEW",
+          SqlKind.DROP_MATERIALIZED_VIEW);
+
+  /** Creates a SqlDropMaterializedView. */
+  SqlDropMaterializedView(SqlParserPos pos, boolean ifExists,
+      SqlIdentifier name) {
+    super(OPERATOR, pos, ifExists, name);
+  }
+
+  @Override public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair =
+        SqlDdlNodes.schema(context, true, name);
+    final Table table = pair.left.plus().getTable(pair.right);
+    if (table != null) {
+      // Materialized view exists.
+      super.execute(context);
+      if (table instanceof Wrapper) {
+        final MaterializationKey materializationKey =
+            ((Wrapper) table).unwrap(MaterializationKey.class);
+        if (materializationKey != null) {
+          MaterializationService.instance()
+              .removeMaterialization(materializationKey);
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropObject.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropObject.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Base class for parse trees of {@code DROP TABLE}, {@code DROP VIEW},
+ * {@code DROP MATERIALIZED VIEW} and {@code DROP TYPE} statements.
+ */
+abstract class SqlDropObject extends SqlDrop
+    implements SqlExecutableStatement {
+  public final SqlIdentifier name;
+
+  /** Creates a SqlDropObject. */
+  SqlDropObject(SqlOperator operator, SqlParserPos pos, boolean ifExists,
+      SqlIdentifier name) {
+    super(operator, pos, ifExists);
+    this.name = name;
+  }
+
+  public List<SqlNode> getOperandList() {
+    return ImmutableList.of(name);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword(getOperator().getName()); // "DROP TABLE" etc.
+    if (ifExists) {
+      writer.keyword("IF EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final List<String> path = context.getDefaultSchemaPath();
+    CalciteSchema schema = context.getRootSchema();
+    for (String p : path) {
+      schema = schema.getSubSchema(p, true);
+    }
+    final boolean existed;
+    switch (getKind()) {
+    case DROP_TABLE:
+    case DROP_MATERIALIZED_VIEW:
+      existed = schema.removeTable(name.getSimple());
+      if (!existed && !ifExists) {
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.tableNotFound(name.getSimple()));
+      }
+      break;
+    case DROP_VIEW:
+      // Not quite right: removes any other functions with the same name
+      existed = schema.removeFunction(name.getSimple());
+      if (!existed && !ifExists) {
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.viewNotFound(name.getSimple()));
+      }
+      break;
+    case DROP_TYPE:
+      existed = schema.removeType(name.getSimple());
+      if (!existed && !ifExists) {
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.typeNotFound(name.getSimple()));
+      }
+      break;
+    case DROP_FUNCTION:
+      existed = schema.removeFunction(name.getSimple());
+      if (!existed && !ifExists) {
+        throw SqlUtil.newContextException(name.getParserPosition(),
+            RESOURCE.functionNotFound(name.getSimple()));
+      }
+      break;
+    case OTHER_DDL:
+    default:
+      throw new AssertionError(getKind());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropSchema.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropSchema.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code DROP TABLE} statement.
+ */
+public class SqlDropSchema extends SqlDrop
+    implements SqlExecutableStatement {
+  private final boolean foreign;
+  private final SqlIdentifier name;
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP SCHEMA", SqlKind.DROP_TABLE);
+
+  /** Creates a SqlDropSchema. */
+  SqlDropSchema(SqlParserPos pos, boolean foreign, boolean ifExists,
+      SqlIdentifier name) {
+    super(OPERATOR, pos, ifExists);
+    this.foreign = foreign;
+    this.name = name;
+  }
+
+  public List<SqlNode> getOperandList() {
+    return ImmutableList.of(
+        SqlLiteral.createBoolean(foreign, SqlParserPos.ZERO), name);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DROP");
+    if (foreign) {
+      writer.keyword("FOREIGN");
+    }
+    writer.keyword("SCHEMA");
+    if (ifExists) {
+      writer.keyword("IF EXISTS");
+    }
+    name.unparse(writer, leftPrec, rightPrec);
+  }
+
+  public void execute(CalcitePrepare.Context context) {
+    final List<String> path = context.getDefaultSchemaPath();
+    CalciteSchema schema = context.getRootSchema();
+    for (String p : path) {
+      schema = schema.getSubSchema(p, true);
+    }
+    final boolean existed = schema.removeSubSchema(name.getSimple());
+    if (!existed && !ifExists) {
+      throw SqlUtil.newContextException(name.getParserPosition(),
+          RESOURCE.schemaNotFound(name.getSimple()));
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropTable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Parse tree for {@code DROP TABLE} statement.
+ */
+public class SqlDropTable extends SqlDropObject {
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP TABLE", SqlKind.DROP_TABLE);
+
+  /** Creates a SqlDropTable. */
+  SqlDropTable(SqlParserPos pos, boolean ifExists, SqlIdentifier name) {
+    super(OPERATOR, pos, ifExists, name);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropType.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Parse tree for {@code DROP TYPE} statement.
+ */
+public class SqlDropType extends SqlDropObject {
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP TYPE", SqlKind.DROP_TYPE);
+
+  SqlDropType(SqlParserPos pos, boolean ifExists, SqlIdentifier name) {
+    super(OPERATOR, pos, ifExists, name);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlDropView.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDropView.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Parse tree for {@code DROP VIEW} statement.
+ */
+public class SqlDropView extends SqlDropObject {
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP VIEW", SqlKind.DROP_VIEW);
+
+  /** Creates a SqlDropView. */
+  SqlDropView(SqlParserPos pos, boolean ifExists, SqlIdentifier name) {
+    super(OPERATOR, pos, ifExists, name);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlExecMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlExecMacro.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code EXEC} statement.
+ */
+public class SqlExecMacro extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("EXECUTE", SqlKind.OTHER);
+
+  private final SqlIdentifier name;
+
+  /** Creates a SqlExecMacro. */
+  public SqlExecMacro(SqlParserPos pos, SqlIdentifier name) {
+    super(pos);
+    this.name = Objects.requireNonNull(name);
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("EXECUTE");
+    name.unparse(writer, leftPrec, rightPrec);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlIndex.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIndex.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A <code>SqlIndex</code> is a class that can be used to create an index used by the
+ * SQL CREATE TABLE function.
+ */
+public abstract class SqlIndex {
+  protected final SqlParserPos pos;
+  protected final SqlNodeList columns;
+  protected final SqlIdentifier name;
+  protected final boolean isUnique;
+
+  protected SqlIndex(SqlParserPos pos, SqlNodeList columns, SqlIdentifier name, boolean isUnique) {
+    this.pos = pos;
+    this.columns = columns;
+    this.name = name;
+    this.isUnique = isUnique;
+  }
+
+  public abstract void unparse(SqlWriter writer, int leftPrec, int rightPrec);
+
+  public SqlParserPos getParserPos() {
+    return pos;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlKeyConstraint.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKeyConstraint.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * Parse tree for {@code UNIQUE}, {@code PRIMARY KEY} constraints.
+ *
+ * <p>And {@code FOREIGN KEY}, when we support it.
+ */
+public class SqlKeyConstraint extends SqlCall {
+  private static final SqlSpecialOperator UNIQUE =
+      new SqlSpecialOperator("UNIQUE", SqlKind.UNIQUE);
+
+  protected static final SqlSpecialOperator PRIMARY =
+      new SqlSpecialOperator("PRIMARY KEY", SqlKind.PRIMARY_KEY);
+
+  private final SqlIdentifier name;
+  private final SqlNodeList columnList;
+
+  /** Creates a SqlKeyConstraint. */
+  SqlKeyConstraint(SqlParserPos pos, SqlIdentifier name,
+      SqlNodeList columnList) {
+    super(pos);
+    this.name = name;
+    this.columnList = columnList;
+  }
+
+  /** Creates a UNIQUE constraint. */
+  public static SqlKeyConstraint unique(SqlParserPos pos, SqlIdentifier name,
+      SqlNodeList columnList) {
+    return new SqlKeyConstraint(pos, name, columnList);
+  }
+
+  /** Creates a PRIMARY KEY constraint. */
+  public static SqlKeyConstraint primary(SqlParserPos pos, SqlIdentifier name,
+      SqlNodeList columnList) {
+    return new SqlKeyConstraint(pos, name, columnList) {
+      @Override public SqlOperator getOperator() {
+        return PRIMARY;
+      }
+    };
+  }
+
+  @Override public SqlOperator getOperator() {
+    return UNIQUE;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name, columnList);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (name != null) {
+      writer.keyword("CONSTRAINT");
+      name.unparse(writer, 0, 0);
+    }
+    writer.keyword(getOperator().getName()); // "UNIQUE" or "PRIMARY KEY"
+    columnList.unparse(writer, 1, 1);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlPrimaryIndex.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPrimaryIndex.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/**
+ * A <code>SqlPrimaryIndex</code> is a class that can be used to create a primary index,
+ * which is used by the SQL CREATE TABLE function.
+ */
+public class SqlPrimaryIndex extends SqlIndex {
+  private final boolean explicitNoPrimaryIndex;
+
+  public SqlPrimaryIndex(SqlParserPos pos, SqlNodeList columns,
+                         SqlIdentifier name, boolean isUnique, boolean explicitNoPrimaryIndex) {
+    super(pos, columns, name, isUnique);
+    this.explicitNoPrimaryIndex = explicitNoPrimaryIndex;
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    if (explicitNoPrimaryIndex) {
+      writer.keyword("NO PRIMARY INDEX");
+      return;
+    }
+    if (isUnique) {
+      writer.keyword("UNIQUE");
+    }
+    writer.keyword("PRIMARY INDEX");
+    if (name != null) {
+      name.unparse(writer, leftPrec, rightPrec);
+    }
+    if (columns != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode c : columns) {
+        writer.sep(",");
+        c.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlRenameTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlRenameTable.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * Parse tree for {@code RENAME TABLE} statement.
+ */
+public class SqlRenameTable extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("RENAME TABLE", SqlKind.RENAME_TABLE);
+
+  private final SqlIdentifier targetTable;
+  private final SqlIdentifier sourceTable;
+  private final RenameOption renameOption;
+
+  /** Creates a SqlRename. */
+  public SqlRenameTable(SqlParserPos pos, SqlIdentifier targetTable,
+      SqlIdentifier sourceTable, RenameOption renameOption) {
+    super(pos);
+    this.targetTable = targetTable;
+    this.sourceTable = sourceTable;
+    this.renameOption = renameOption;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(targetTable, sourceTable);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("RENAME TABLE");
+    targetTable.unparse(writer, leftPrec, rightPrec);
+    writer.keyword(renameOption.toString());
+    sourceTable.unparse(writer, leftPrec, rightPrec);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+
+  public enum RenameOption {
+    /**
+     * Query used the TO keyword.
+     */
+    TO,
+
+    /**
+     * Query used the AS keyword.
+     */
+    AS
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetTimeZone.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetTimeZone.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+public class SqlSetTimeZone extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("SET TIME ZONE", SqlKind.OTHER);
+
+  private final SqlIdentifier name;
+
+  public SqlSetTimeZone(SqlParserPos pos, SqlIdentifier name) {
+    super(pos);
+    this.name = name;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(name);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SET TIME ZONE");
+    name.unparse(writer, leftPrec, rightPrec);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlTranslateUsingCharacterSet.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTranslateUsingCharacterSet.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * A {@code SqlTranslateUsingCharacterSet} is an AST node that describes
+ * the Translate Using CharacterSet to CharacterSet with Error.
+ */
+public class SqlTranslateUsingCharacterSet extends SqlCall implements SqlExecutableStatement {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("TRANSLATE ", SqlKind.OTHER_FUNCTION);
+
+  private final List<SqlNode> args;
+  private final boolean isWithError;
+
+  /**
+   * Creates a {@code SqlTranslateUsingCharacterSet}.
+   *
+   * @param pos  Parser position, must not be null
+   * @param args  List of SqlNode, the first one is an char sequence to be
+   *              translated, the second one is the AST node of SqlCharacterSetToCharacterSet
+   * @param isWithError If the with error token is specified
+   */
+  public SqlTranslateUsingCharacterSet(final SqlParserPos pos, final List<SqlNode> args,
+      final boolean isWithError) {
+    super(pos);
+    this.args = args;
+    this.isWithError = isWithError;
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(args.get(0), args.get(1));
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec,
+      final int rightPrec) {
+    writer.keyword("TRANSLATE");
+    writer.print("(");
+    args.get(0).unparse(writer, 0, 0);
+    writer.keyword("USING");
+    args.get(1).unparse(writer, 0, 0);
+    writer.setNeedWhitespace(true);
+    if (isWithError) {
+      writer.keyword("WITH ERROR");
+    }
+    writer.print(")");
+  }
+
+  // Intentionally leave empty
+  @Override public void execute(final CalcitePrepare.Context context) {
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpsert.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpsert.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code UPSERT form of UPDATE} statement.
+ */
+public class SqlUpsert extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("UPSERT", SqlKind.OTHER);
+
+  private final SqlUpdate updateCall;
+  private final SqlInsert insertCall;
+
+  /** Creates a SqlUpsert */
+  public SqlUpsert(SqlParserPos pos, SqlUpdate updateCall, SqlInsert insertCall) {
+    super(pos);
+    this.updateCall = Objects.requireNonNull(updateCall);
+    this.insertCall = Objects.requireNonNull(insertCall);
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(updateCall, insertCall);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    updateCall.unparse(writer, leftPrec, rightPrec);
+    writer.keyword("ELSE");
+    insertCall.unparse(writer, leftPrec, rightPrec);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlUsingRequestModifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUsingRequestModifier.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code USING} statement.
+ */
+public class SqlUsingRequestModifier extends SqlCall implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("USING", SqlKind.OTHER);
+
+  private final SqlNodeList columnList;
+
+  /** Creates a SqlUsingRequestModifier */
+  public SqlUsingRequestModifier(SqlParserPos pos, SqlNodeList columnList) {
+    super(pos);
+    this.columnList = Objects.requireNonNull(columnList);
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(columnList);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("USING");
+    SqlWriter.Frame frame = writer.startList("(", ")");
+    for (SqlNode c : columnList) {
+      writer.sep(",");
+      c.unparse(writer, 0, 0);
+    }
+    writer.endList(frame);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/Volatility.java
+++ b/core/src/main/java/org/apache/calcite/sql/Volatility.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+/**
+ * Enumerates the types of volatility.
+ */
+public enum Volatility {
+  /**
+   * Volatility type not specified.
+   */
+  UNSPECIFIED,
+
+  /**
+   * Volatile is used as the keyword for volatility.
+   */
+  VOLATILE,
+
+  /**
+   * Temp is used as the keyword for volatility.
+   */
+  TEMP,
+}

--- a/core/src/main/java/org/apache/calcite/sql/WithDataType.java
+++ b/core/src/main/java/org/apache/calcite/sql/WithDataType.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+/**
+ * Enumerates the types of WITH DATA clauses.
+ */
+public enum WithDataType {
+  /**
+   * The existence of whether data is included or not is not specified. Same behavior as NO_DATA.
+   */
+  UNSPECIFIED,
+
+  /**
+   * Table is created with the same schema and data.
+   */
+  WITH_DATA,
+
+  /**
+   * Table is explicitly created with the specified schema, but no data.
+   */
+  WITH_NO_DATA,
+}

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -52,7 +52,7 @@ data: {
       "org.apache.calcite.sql.SqlCreateAttributeMap",
       "org.apache.calcite.sql.SqlCreateAttributeMergeBlockRatio",
       "org.apache.calcite.sql.SqlCreateAttributeMergeBlockRatio.MergeBlockRatioModifier",
-      "org.apache.calcite.sql.SqlCreateTableDialectA",
+      "org.apache.calcite.sql.SqlCreateTableDialect1",
       "org.apache.calcite.sql.SqlDdlNodes",
       "org.apache.calcite.sql.SqlExecMacro",
       "org.apache.calcite.sql.SqlRenameTable",

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -582,7 +582,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace) :
     )*
     onCommitType = OnCommitTypeOpt()
     {
-        return new SqlCreateTableDialectA(s.end(this), replace, setType, volatility, ifNotExists, id,
+        return new SqlCreateTableDialect1(s.end(this), replace, setType, volatility, ifNotExists, id,
             tableAttributes, columnList, query, withData, primaryIndex, onCommitType);
     }
 }


### PR DESCRIPTION
Notes:
 - SqlCreateTable from babel is renamed to SqlCreateTableDialect1 since this class also exists in server