### PR TITLE
[CALCITE] Allow indices to be optionally separated by commas

### DIFF
--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -622,7 +622,7 @@ SqlCreate SqlCreateTable(Span s, SqlCreateSpecifier createSpecifier) :
     [
         index = SqlCreateTableIndex(s) { indices.add(index); }
         (
-           <COMMA> index = SqlCreateTableIndex(s) { indices.add(index); }
+           [<COMMA>] index = SqlCreateTableIndex(s) { indices.add(index); }
         )*
         {
             // Filter out any primary indices from index list.

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -1841,6 +1841,14 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testPrimaryIndexWithSecondaryIndexWithoutComma() {
+    final String sql = "create table foo (bar integer, qux integer) "
+        + "primary index (bar) index (qux)";
+    final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER, `QUX` INTEGER) "
+        + "PRIMARY INDEX (`BAR`), INDEX (`QUX`)";
+    sql(sql).ok(expected);
+  }
+
   @Test void testTopNNoPercentNoTies() {
     final String sql = "select top 5 bar from foo";
     final String expected = "SELECT TOP 5 `BAR`\n"


### PR DESCRIPTION
[CALCITE] Allow indices to be optionally separated by commas
