### PR TITLE
[CALCITE] Add abbreviated keywords to server module

### DIFF
--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -39,6 +39,10 @@ data: {
       "JAR"
       "FILE"
       "ARCHIVE"
+      "DEL"
+      "INS"
+      "SEL"
+      "UPD"
     ]
 
     # List of keywords from "keywords" section that are not reserved.
@@ -483,7 +487,7 @@ data: {
 
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
-    allowAbbreviatedKeywords: false
+    allowAbbreviatedKeywords: true
     allowTranslateUsingCharSetWithError: false
     includePosixOperators: false
     includeCastFormat: false

--- a/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
@@ -333,4 +333,30 @@ class ServerParserTest extends SqlParserTest {
         + "FROM `BAR`";
     sql(sql).ok(expected);
   }
+
+  @Test void testDel() {
+    final String sql = "del from t";
+    final String expected = "DELETE FROM `T`";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testIns() {
+    final String sql = "ins into foo (a, b) values (1,'hi')";
+    final String expected = "INSERT INTO `FOO` (`A`, `B`)\n"
+        + "VALUES (ROW(1, 'hi'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testSel() {
+    final String sql = "sel 1 from t";
+    final String expected = "SELECT 1\n"
+        + "FROM `T`";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testUpd() {
+    final String sql = "upd foo set x = 1";
+    final String expected = "UPDATE `FOO` SET `X` = 1";
+    sql(sql).ok(expected);
+  }
 }


### PR DESCRIPTION
[CALCITE] Add abbreviated keywords to server module

This add supports for the following abbreviations in the server module:
- DEL (aka DELETE)
- INS (aka INSERT)
- SEL (aka SELECT)
- UPD (aka UPDATE)
