### PR TITLE
[CALCITE] Added support for INSERT with omitted values

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -1088,6 +1088,7 @@ data: {
     includeAlternativeTypeConversionQuery: true
     includeRankWithSortingExpressions: true
     includeTopN: true
+    includeInsertWithOmittedValues: true
   }
 }
 

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -1039,29 +1039,32 @@ SqlNode LiteralRowConstructor() :
 }
 {
     <LPAREN>
+    e = LiteralRowConstructorItem()
+    { valueList.add(e); }
+    (
+        <COMMA>
+        e = LiteralRowConstructorItem()
+        { valueList.add(e); }
+    )*
+    <RPAREN>
+    {
+        return SqlStdOperatorTable.ROW.createCall(s.end(valueList),
+            valueList.toArray());
+    }
+}
+
+SqlNode LiteralRowConstructorItem() :
+{
+    SqlNode e;
+}
+{
     (
         e = AtomicRowExpression()
     |
         { e = SqlLiteral.createNull(getPos()); }
     )
     {
-        valueList.add(e);
-    }
-    (
-        <COMMA>
-        (
-            e = AtomicRowExpression()
-        |
-            { e = SqlLiteral.createNull(getPos()); }
-        )
-        {
-            valueList.add(e);
-        }
-    )*
-    <RPAREN>
-    {
-        return SqlStdOperatorTable.ROW.createCall(s.end(valueList),
-            valueList.toArray());
+        return e;
     }
 }
 

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -1039,10 +1039,24 @@ SqlNode LiteralRowConstructor() :
 }
 {
     <LPAREN>
-    e = AtomicRowExpression() { valueList.add(e); }
     (
-        LOOKAHEAD(2)
-        <COMMA> e = AtomicRowExpression() { valueList.add(e); }
+        e = AtomicRowExpression()
+    |
+        { e = SqlLiteral.createNull(getPos()); }
+    )
+    {
+        valueList.add(e);
+    }
+    (
+        <COMMA>
+        (
+            e = AtomicRowExpression()
+        |
+            { e = SqlLiteral.createNull(getPos()); }
+        )
+        {
+            valueList.add(e);
+        }
     )*
     <RPAREN>
     {

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -2004,14 +2004,14 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
-  @Test public void testInsertOneOmittedValueNoValueKeyword() {
+  @Test public void testInsertOneOmittedValueNoValuesKeyword() {
     final String sql = "insert into foo (1,,'hi')";
     final String expected = "INSERT INTO `FOO`\n"
         + "VALUES (ROW(1, NULL, 'hi'))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testInsertAllOmittedValuesNoValueKeyword() {
+  @Test public void testInsertAllOmittedValuesNoValuesKeyword() {
     final String sql = "insert into foo (,,)";
     final String expected = "INSERT INTO `FOO`\n"
         + "VALUES (ROW(NULL, NULL, NULL))";

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -1989,4 +1989,32 @@ class BabelParserTest extends SqlParserTest {
     final String expected = "(?s).*Numeric literal.*out of range.*";
     sql(sql).fails(expected);
   }
+
+  @Test public void testInsertOneOmittedValue() {
+    final String sql = "insert into foo values (1,,'hi')";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "VALUES (ROW(1, NULL, 'hi'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testInsertAllOmittedValues() {
+    final String sql = "insert into foo values (,,)";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "VALUES (ROW(NULL, NULL, NULL))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testInsertOneOmittedValueNoValueKeyword() {
+    final String sql = "insert into foo (1,,'hi')";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "VALUES (ROW(1, NULL, 'hi'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testInsertAllOmittedValuesNoValueKeyword() {
+    final String sql = "insert into foo (,,)";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "VALUES (ROW(NULL, NULL, NULL))";
+    sql(sql).ok(expected);
+  }
 }

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -485,6 +485,7 @@ data: {
     includeAlternativeTypeConversionQuery: false
     includeRankWithSortingExpressions: false
     includeTopN: false
+    includeInsertWithOmittedValues: false
   }
 }
 

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -800,6 +800,9 @@ SqlNodeList ParenthesizedQueryOrCommaListWithDefault(
         e = Default()
 <#if parser.includeInsertWithOmittedValues>
     |
+        // This LOOKAHEAD ensures that parsing fails if there is an empty set of
+        // parentheses after a VALUE keyword since that is invalid syntax in
+        // most dialects
         LOOKAHEAD({ getToken(1).kind != RPAREN })
         { e = SqlLiteral.createNull(getPos()); }
 </#if>

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -801,7 +801,7 @@ SqlNodeList ParenthesizedQueryOrCommaListWithDefault(
 <#if parser.includeInsertWithOmittedValues>
     |
         // This LOOKAHEAD ensures that parsing fails if there is an empty set of
-        // parentheses after a VALUE keyword since that is invalid syntax in
+        // parentheses after a VALUES keyword since that is invalid syntax in
         // most dialects
         LOOKAHEAD({ getToken(1).kind != RPAREN })
         { e = SqlLiteral.createNull(getPos()); }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -798,6 +798,11 @@ SqlNodeList ParenthesizedQueryOrCommaListWithDefault(
         e = OrderedQueryOrExpr(firstExprContext)
     |
         e = Default()
+<#if parser.includeInsertWithOmittedValues>
+    |
+        LOOKAHEAD({ getToken(1).kind != RPAREN })
+        { e = SqlLiteral.createNull(getPos()); }
+</#if>
     )
     {
         list = startList(e);
@@ -812,6 +817,10 @@ SqlNodeList ParenthesizedQueryOrCommaListWithDefault(
             e = Expression(exprContext)
         |
             e = Default()
+<#if parser.includeInsertWithOmittedValues>
+        |
+            { e = SqlLiteral.createNull(getPos()); }
+</#if>
         )
         {
             list.add(e);
@@ -1625,6 +1634,7 @@ SqlNode SqlInsert() :
     (
 <#-- additional literal parser methods are included here -->
 <#list parser.insertStatementParserMethods as method>
+        LOOKAHEAD(${method}())
         source = ${method}()
     |
 </#list>

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -468,6 +468,7 @@ data: {
     includeAlternativeTypeConversionQuery: false
     includeRankWithSortingExpressions: false
     includeTopN: false
+    includeInsertWithOmittedValues: false
   }
 }
 

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -499,6 +499,7 @@ data: {
     includeAlternativeTypeConversionQuery: false
     includeRankWithSortingExpressions: false
     includeTopN: false
+    includeInsertWithOmittedValues: false
   }
 }
 


### PR DESCRIPTION
Added support for omitted values in an INSERT statement:
`INSERT INTO <table_name> [VALUES] \(<value>?(,<value>?)*\);`