### PR TITLE
[CALCITE] Add support for colon separator in compound identifiers

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -1085,6 +1085,7 @@ data: {
     includePosixOperators: true
     includeCastFormat: true
     includeCompoundIdentifier: true
+    allowColonSeparatorInCompoundIdentifier: true
     includeBraces: true
     includeAdditionalDeclarations: false
     includeSubstrKeyword: true

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -270,6 +270,20 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testCompoundIdentifierWithColonSeparator() {
+    final String sql = "select * from foo:bar";
+    final String expected = "SELECT *\n"
+        + "FROM `FOO`.`BAR`";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCompoundIdentifierWithColonAndDotSeparators() {
+    final String sql = "select * from foo:bar.baz";
+    final String expected = "SELECT *\n"
+        + "FROM `FOO`.`BAR`.`BAZ`";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testCreateOrReplaceTable() {
     final String sql = "create or replace table foo (bar integer)";
     final String expected = "CREATE OR REPLACE TABLE `FOO` (`BAR` INTEGER)";

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -478,6 +478,7 @@ data: {
     includePosixOperators: false
     includeCastFormat: false
     includeCompoundIdentifier: true
+    allowColonSeparatorInCompoundIdentifier: false
     includeBraces: true
     includeAdditionalDeclarations: false
     includeSubstrKeyword: false

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -4919,7 +4919,7 @@ SqlNodeList ParenthesizedSimpleIdentifierList() :
     }
 }
 
-<#if parser.includeCompoundIdentifier >
+<#if parser.includeCompoundIdentifier>
 /**
  * Parses a compound identifier.
  */
@@ -4931,6 +4931,13 @@ SqlIdentifier CompoundIdentifier() :
 }
 {
     IdentifierSegment(nameList, posList)
+<#if parser.allowColonSeparatorInCompoundIdentifier>
+    [
+        LOOKAHEAD(2)
+        <COLON>
+        IdentifierSegment(nameList, posList)
+    ]
+</#if>
     (
         LOOKAHEAD(2)
         <DOT>
@@ -6057,9 +6064,14 @@ SqlNode JsonName() :
     final SqlNode e;
 }
 {
-     e = Expression(ExprContext.ACCEPT_NON_QUERY) {
+    (
+        e = SimpleIdentifier()
+    |
+        e = StringLiteral()
+    )
+    {
         return e;
-     }
+    }
 }
 
 List<SqlNode> JsonNameAndValue() :

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -461,6 +461,7 @@ data: {
     includePosixOperators: false
     includeCastFormat: false
     includeCompoundIdentifier: true
+    allowColonSeparatorInCompoundIdentifier: false
     includeBraces: true
     includeAdditionalDeclarations: false
     includeSubstrKeyword: false

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1650,9 +1650,6 @@ public class SqlParserTest {
             + "WHERE (`A` LIKE `B` ESCAPE `C`)) ESCAPE `D`)))");
   }
 
-  @Test void testFoo() {
-  }
-
   @Test void testArithmeticOperators() {
     expr("1-2+3*4/5/6-7")
         .ok("(((1 - 2) + (((3 * 4) / 5) / 6)) - 7)");

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -492,6 +492,7 @@ data: {
     includePosixOperators: false
     includeCastFormat: false
     includeCompoundIdentifier: true
+    allowColonSeparatorInCompoundIdentifier: false
     includeBraces: true
     includeAdditionalDeclarations: false
     includeSubstrKeyword: false


### PR DESCRIPTION
[CALCITE] Add support for colon separator in compound identifiers

This change also modifies the way JSON names are extracted because the previous logic erroneously used the Expression() parsing function to extract only a string literal or an identifier. This did not work once <COLON> was added as an allowed part of a compound identifier for an input key/value pair. For example, "foo: bar".
