### PR TITLE
[CALCITE] Add support for inline FORMAT clause

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -1061,9 +1061,15 @@ data: {
       "InfixCast"
     ]
 
-    preAtomicRowMethods: [
-      "InlineModOperator()"
-      "AlternativeTypeConversionLiteralOrIdentifier()"
+    preExpressionMethods: [
+      "InlineModOperator"
+      "AlternativeTypeConversionLiteralOrIdentifier"
+      "InlineFormatLiteralOrIdentifier"
+    ]
+
+    postExpressionMethods: [
+      "AlternativeTypeConversionQuery"
+      "InlineFormatQuery"
     ]
 
     dateTimeExpressionMethods: [
@@ -1090,7 +1096,6 @@ data: {
     includeAdditionalDeclarations: false
     includeSubstrKeyword: true
     includeQualifyClause: true
-    includeAlternativeTypeConversionQuery: true
     includeRankWithSortingExpressions: true
     includeTopN: true
   }

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -1294,51 +1294,62 @@ SqlTypeNameSpec TypeNameAlternativeCastSyntax() :
 
 SqlNode AlternativeTypeConversionLiteralOrIdentifier() :
 {
-     final List<SqlNode> args;
-     final SqlDataTypeSpec dt;
-     SqlNode e;
-     final Span s;
+     final SqlNode q;
+     final SqlNode e;
 }
 {
     (
-        e = Literal()
+        q = Literal()
     |
-        e = SimpleIdentifier()
+        q = SimpleIdentifier()
     )
-    {
-        s = span();
-        args = startList(e);
-    }
+    e = AlternativeTypeConversionQuery(q) { return e; }
+}
+
+SqlNode AlternativeTypeConversionQuery(SqlNode q) :
+{
+    final Span s = span();
+    final List<SqlNode> args = startList(q);
+    final SqlDataTypeSpec dt;
+    final SqlNode interval;
+    final SqlNode format;
+}
+{
     <LPAREN>
     (
         dt = DataTypeAlternativeCastSyntax() { args.add(dt); }
     |
-        <INTERVAL> e = IntervalQualifier() { args.add(e); }
+        <INTERVAL> interval = IntervalQualifier() { args.add(interval); }
     )
-    [ <FORMAT> e = StringLiteral() { args.add(e); } ]
+    [ <FORMAT> format = StringLiteral() { args.add(format); } ]
     <RPAREN> {
         return SqlStdOperatorTable.CAST.createCall(s.end(this), args);
     }
 }
 
-SqlNode AlternativeTypeConversionQuery(SqlNode query) :
+SqlNode InlineFormatLiteralOrIdentifier() :
 {
-    final List<SqlNode> args = startList(query);
-    final SqlDataTypeSpec dt;
-    final Span s;
-    SqlNode e;
+     final SqlNode q;
+     final SqlNode e;
 }
 {
-    { s = span(); }
-    <LPAREN>
     (
-        dt = DataTypeAlternativeCastSyntax() { args.add(dt); }
+        q = Literal()
     |
-        <INTERVAL> e = IntervalQualifier() { args.add(e); }
+        q = SimpleIdentifier()
     )
-    [ <FORMAT> e = StringLiteral() { args.add(e); } ]
-    <RPAREN> {
-        return SqlStdOperatorTable.CAST.createCall(s.end(this), args);
+    e = InlineFormatQuery(q) { return e; }
+}
+
+SqlNode InlineFormatQuery(SqlNode q) :
+{
+    final Span s = span();
+    final SqlNode format;
+}
+{
+    <LPAREN> <FORMAT> format = StringLiteral() <RPAREN>
+    {
+        return SqlStdOperatorTable.FORMAT.createCall(s.end(this), q, format);
     }
 }
 

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -1724,6 +1724,38 @@ class BabelParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test void testInlineFormatIdentifier() {
+    final String sql = "select foo (format 'XXX')";
+    final String expected = "SELECT (`FOO` (FORMAT 'XXX'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testInlineFormatNumericLiteral() {
+    final String sql = "select 12.5 (format '9.99E99')";
+    final String expected = "SELECT (12.5 (FORMAT '9.99E99'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testInlineFormatStringLiteral() {
+    final String sql = "select 12.5 (format 'XXX')";
+    final String expected = "SELECT (12.5 (FORMAT 'XXX'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testInlineFormatDateLiteral() {
+    final String sql = "select current_date (format 'yyyy-mm-dd')";
+    final String expected = "SELECT (CURRENT_DATE (FORMAT 'yyyy-mm-dd'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testInlineFormatQuery() {
+    final String sql = "select (select foo from bar) (format 'XXX') from baz";
+    final String expected = "SELECT ((SELECT `FOO`\n"
+        + "FROM `BAR`) (FORMAT 'XXX'))\n"
+        + "FROM `BAZ`";
+    sql(sql).ok(expected);
+  }
+
   @Test void testAlternativeTypeConversionIdentifier() {
     final String sql = "select foo (integer)";
     final String expected = "SELECT CAST(`FOO` AS INTEGER)";

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -457,7 +457,10 @@ data: {
     extraBinaryExpressions: [
     ]
 
-    preAtomicRowMethods: [
+    preExpressionMethods: [
+    ]
+
+    postExpressionMethods: [
     ]
 
     dateTimeExpressionMethods: [
@@ -483,7 +486,6 @@ data: {
     includeAdditionalDeclarations: false
     includeSubstrKeyword: false
     includeQualifyClause: false
-    includeAlternativeTypeConversionQuery: false
     includeRankWithSortingExpressions: false
     includeTopN: false
   }

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3650,9 +3650,9 @@ SqlNode Expression3(ExprContext exprContext) :
     Span rowSpan = null;
 }
 {
-<#list parser.preAtomicRowMethods as method>
-    LOOKAHEAD(${method})
-    e = ${method} { return e; }
+<#list parser.preExpressionMethods as method>
+    LOOKAHEAD(${method}())
+    e = ${method}() { return e; }
 |
 </#list>
     LOOKAHEAD(2)
@@ -3741,10 +3741,10 @@ SqlNode Expression3(ExprContext exprContext) :
         }
     }
     (
-<#if parser.includeAlternativeTypeConversionQuery>
-        e = AlternativeTypeConversionQuery(list1.get(0)) { return e; }
+<#list parser.postExpressionMethods as method>
+        e = ${method}(list1.get(0)) { return e; }
     |
-</#if>
+</#list>
         { return list1.get(0); }
     )
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -729,6 +729,12 @@ public enum SqlKind {
   CAST,
 
   /**
+   * The "FORMAT" operator.
+   */
+  FORMAT,
+
+
+  /**
    * The "NEXT VALUE OF sequence" operator.
    */
   NEXT_VALUE,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlFormatFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlFormatFunction.java
@@ -14,38 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.calcite.sql.babel;
+package org.apache.calcite.sql.fun;
 
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlWriter;
 
-import java.util.Objects;
-
 /**
- * A {@code SqlAlterTableAddColumns} represents an ADD column statement within
- * an ALTER TABLE query.
- */
-public class SqlAlterTableAddColumns extends SqlAlterTableOption {
-
-  public final SqlNodeList columns;
-
-  /**
-   * Creates a {@code SqlAlterTableAddColumns}.
-   * @param columns  The list of columns to add. Must be non-null and non-empty
+   * The SQL <code>FORMAT</code> operator.
+   *
+   * <p>The SQL syntax is
+   *
+   * <blockquote><code>FORMAT(<i>expression</i> <i>literal</i>)</code>
+   * </blockquote>
    */
-  public SqlAlterTableAddColumns(SqlNodeList columns) {
-    this.columns = Objects.requireNonNull(columns);
+public class SqlFormatFunction extends SqlFunction {
+
+  public SqlFormatFunction() {
+    super("FORMAT", SqlKind.FORMAT, null, null, null, SqlFunctionCategory.STRING);
   }
 
-  @Override public void unparse(SqlWriter writer,
-      int leftPrec, int rightPrec) {
-    writer.keyword("ADD");
-    SqlWriter.Frame frame = writer.startList("(", ")");
-    for (SqlNode c : columns) {
-      writer.sep(",");
-      c.unparse(writer, 0, 0);
-    }
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    call.operand(0).unparse(writer, 0, 0);
+    final SqlWriter.Frame frame = writer.startList("(", ")");
+    writer.keyword(getName());
+    call.operand(1).unparse(writer, 0, 0);
     writer.endList(frame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1934,6 +1934,16 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
   public static final SqlFunction CAST = new SqlCastFunction();
 
   /**
+   * The SQL <code>FORMAT</code> operator.
+   *
+   * <p>The SQL syntax is
+   *
+   * <blockquote><code>FORMAT(<i>expression</i> <i>literal</i>)</code>
+   * </blockquote>
+   */
+  public static final SqlFunction FORMAT = new SqlFormatFunction();
+
+  /**
    * The SQL <code>EXTRACT</code> operator. Extracts a specified field value
    * from a DATETIME or an INTERVAL. E.g.<br>
    * <code>EXTRACT(HOUR FROM INTERVAL '364 23:59:59')</code> returns <code>

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -440,7 +440,10 @@ data: {
     extraBinaryExpressions: [
     ]
 
-    preAtomicRowMethods: [
+    preExpressionMethods: [
+    ]
+
+    postExpressionMethods: [
     ]
 
     dateTimeExpressionMethods: [
@@ -466,7 +469,6 @@ data: {
     includeAdditionalDeclarations: false
     includeSubstrKeyword: false
     includeQualifyClause: false
-    includeAlternativeTypeConversionQuery: false
     includeRankWithSortingExpressions: false
     includeTopN: false
   }

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -471,7 +471,10 @@ data: {
     extraBinaryExpressions: [
     ]
 
-    preAtomicRowMethods: [
+    preExpressionMethods: [
+    ]
+
+    postExpressionMethods: [
     ]
 
     dateTimeExpressionMethods: [
@@ -497,7 +500,6 @@ data: {
     includeAdditionalDeclarations: false
     includeSubstrKeyword: false
     includeQualifyClause: false
-    includeAlternativeTypeConversionQuery: false
     includeRankWithSortingExpressions: false
     includeTopN: false
   }


### PR DESCRIPTION
This change also restructures the alternative type casting parsing
logic, while keeping the behavior the same.