### PR TITLE
[CALCITE] Allow numeric literals in JSON names

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6068,6 +6068,8 @@ SqlNode JsonName() :
         e = SimpleIdentifier()
     |
         e = StringLiteral()
+    |
+        e = NumericLiteral()
     )
     {
         return e;

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -49,6 +49,7 @@ here to appease testAllFunctionsAreDocumented:
 | SUCCEEDS       | Documented as a period operator
 | TABLE          | Documented as part of FROM syntax
 | VARIANCE()     | In SqlStdOperatorTable, but not fully implemented
+| FORMAT()       | TODO: document
 {% endcomment %}
 -->
 


### PR DESCRIPTION
This change also adds FORMAT to a list of functions in reference.md to
ignore.