### PR TITLE
[CALCITE] Added support for host variables

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -92,6 +92,7 @@ data: {
       "org.apache.calcite.sql.babel.SqlCharacterSetToCharacterSet",
       "org.apache.calcite.sql.babel.SqlTranslateUsingCharacterSet",
       "org.apache.calcite.sql.babel.SqlColumnAttributeDateFormat",
+      "org.apache.calcite.sql.babel.SqlHostVariable",
     ]
 
     # List of keywords.
@@ -1104,6 +1105,7 @@ data: {
     includeRankWithSortingExpressions: true
     includeTopN: true
     includeInsertWithOmittedValues: true
+    includeHostVariables: true
   }
 }
 

--- a/babel/src/main/codegen/includes/parserImpls.ftl
+++ b/babel/src/main/codegen/includes/parserImpls.ftl
@@ -1094,7 +1094,7 @@ SqlNode SqlExecMacroPositionalParamItem() :
 }
 {
     (
-        e = Literal()
+        e = AtomicRowExpression()
     |
         { e = SqlLiteral.createNull(getPos()); }
     )
@@ -1111,7 +1111,7 @@ SqlNode SqlSimpleIdentifierEqualLiteral() :
 {
     name = SimpleIdentifier()
     <EQ>
-    value = Literal()
+    value = AtomicRowExpression()
     {
         return new SqlExecMacroParam(getPos(), name, value);
     }
@@ -1815,5 +1815,15 @@ SqlNode SqlSelectTopN(SqlParserPos pos) :
         return new SqlSelectTopN(pos, selectNum,
             SqlLiteral.createBoolean(isPercent, pos),
             SqlLiteral.createBoolean(withTies, pos));
+    }
+}
+
+SqlHostVariable SqlHostVariable() :
+{
+}
+{
+    <COLON>
+    <IDENTIFIER> {
+        return new SqlHostVariable(unquotedIdentifier(), getPos());
     }
 }

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlHostVariable.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlHostVariable.java
@@ -38,5 +38,7 @@ public class SqlHostVariable extends SqlIdentifier {
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.print(":");
     writer.print(names.get(0));
+    // Ensures whitespace is added before a separator such as "AS"
+    writer.setNeedWhitespace(true);
   }
 }

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlHostVariable.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlHostVariable.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.babel;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * A {@code SqlHostVariable} is a host variable of the form ":name".
+ */
+public class SqlHostVariable extends SqlIdentifier {
+
+  /**
+   * Creates a {@code SqlHostVariable}.
+   *
+   * @param name  Name of the host variable
+   * @param pos  Parser position, must not be null
+   */
+  public SqlHostVariable(String name, SqlParserPos pos) {
+    super(name, pos);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.print(":");
+    writer.print(names.get(0));
+  }
+}

--- a/babel/src/main/java/org/apache/calcite/sql/babel/SqlHostVariable.java
+++ b/babel/src/main/java/org/apache/calcite/sql/babel/SqlHostVariable.java
@@ -36,9 +36,8 @@ public class SqlHostVariable extends SqlIdentifier {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    writer.print(":");
-    writer.print(names.get(0));
-    // Ensures whitespace is added before a separator such as "AS"
+    writer.print(":" + names.get(0));
+    // Ensures whitespace is added before a separator such as "AS".
     writer.setNeedWhitespace(true);
   }
 }

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -1070,8 +1070,8 @@ class BabelParserTest extends SqlParserTest {
   }
 
   @Test public void testExecuteMacroWithMixedParamPatternFails() {
-    final String sql = "execute foo (1, ^bar^ = '2')";
-    final String expected = "(?s).*Encountered \"bar\" at .*";
+    final String sql = "execute foo (1, bar ^=^ '2')";
+    final String expected = "(?s).*Encountered \"=\" at .*";
     sql(sql).fails(expected);
   }
 
@@ -2257,32 +2257,43 @@ class BabelParserTest extends SqlParserTest {
   }
 
   @Test public void testHostVariableExecPositionalParams() {
-    final String sql = "exec foo(:a, :b, :c)";
-    final String expected = "EXECUTE `FOO` (:a, :b, :c)";
+    final String sql = "exec foo (:bar, :baz, :qux)";
+    final String expected = "EXECUTE `FOO` (:BAR, :BAZ, :QUX)";
     sql(sql).ok(expected);
   }
 
   @Test public void testHostVariableExecNamedParams() {
-    final String sql = "exec foo(bar=:a, baz=:b, qux=:c)";
-    final String expected = "EXECUTE `FOO` (`BAR` = :a, `BAZ` = :b, `QUX` = :c)";
+    final String sql = "exec foo (bar=:bar , baz=:baz , qux=:qux)";
+    final String expected = "EXECUTE `FOO` (`BAR` = :BAR, `BAZ` = :BAZ,"
+        + "`QUX` = :QUX)";
     sql(sql).ok(expected);
   }
 
   @Test public void testHostVariableSelect() {
     final String sql = "select :bar from foo where a = :qux";
-    final String expected = "SELECT :bar FROM where `A` = :qux";
+    final String expected = "SELECT :BAR\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` = :QUX)";
     sql(sql).ok(expected);
   }
 
   @Test public void testHostVariableInsert() {
     final String sql = "insert into foo values (:bar, :baz)";
-    final String expected = "INSERT INTO `FOO` VALUES (:bar, :baz)";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "VALUES (ROW(:BAR, :BAZ))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testHostVariableInsertWithoutValuesKeyword() {
+    final String sql = "insert into foo (:bar, :baz)";
+    final String expected = "INSERT INTO `FOO`\n"
+        + "VALUES (ROW(:BAR, :BAZ))";
     sql(sql).ok(expected);
   }
 
   @Test public void testHostVariableUpdate() {
     final String sql = "update foo set bar = :baz";
-    final String expected = "UPDATE `FOO` SET `BAR` = :baz";
+    final String expected = "UPDATE `FOO` SET `BAR` = :BAZ";
     sql(sql).ok(expected);
   }
 }

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -2263,9 +2263,9 @@ class BabelParserTest extends SqlParserTest {
   }
 
   @Test public void testHostVariableExecNamedParams() {
-    final String sql = "exec foo (bar=:bar , baz=:baz , qux=:qux)";
+    final String sql = "exec foo (bar=:bar, baz=:baz, qux=:qux)";
     final String expected = "EXECUTE `FOO` (`BAR` = :BAR, `BAZ` = :BAZ,"
-        + "`QUX` = :QUX)";
+        + " `QUX` = :QUX)";
     sql(sql).ok(expected);
   }
 
@@ -2294,6 +2294,12 @@ class BabelParserTest extends SqlParserTest {
   @Test public void testHostVariableUpdate() {
     final String sql = "update foo set bar = :baz";
     final String expected = "UPDATE `FOO` SET `BAR` = :BAZ";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testHostVariableCast() {
+    final String sql = "select cast(:foo as bar)";
+    final String expected = "SELECT CAST(:FOO AS `BAR`)";
     sql(sql).ok(expected);
   }
 }

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -2255,4 +2255,34 @@ class BabelParserTest extends SqlParserTest {
         + "VALUES (ROW(NULL, NULL, NULL))";
     sql(sql).ok(expected);
   }
+
+  @Test public void testHostVariableExecPositionalParams() {
+    final String sql = "exec foo(:a, :b, :c)";
+    final String expected = "EXECUTE `FOO` (:a, :b, :c)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testHostVariableExecNamedParams() {
+    final String sql = "exec foo(bar=:a, baz=:b, qux=:c)";
+    final String expected = "EXECUTE `FOO` (`BAR` = :a, `BAZ` = :b, `QUX` = :c)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testHostVariableSelect() {
+    final String sql = "select :bar from foo where a = :qux";
+    final String expected = "SELECT :bar FROM where `A` = :qux";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testHostVariableInsert() {
+    final String sql = "insert into foo values (:bar, :baz)";
+    final String expected = "INSERT INTO `FOO` VALUES (:bar, :baz)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testHostVariableUpdate() {
+    final String sql = "update foo set bar = :baz";
+    final String expected = "UPDATE `FOO` SET `BAR` = :baz";
+    sql(sql).ok(expected);
+  }
 }

--- a/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
+++ b/babel/src/test/java/org/apache/calcite/test/BabelParserTest.java
@@ -2270,8 +2270,8 @@ class BabelParserTest extends SqlParserTest {
   }
 
   @Test public void testHostVariableSelect() {
-    final String sql = "select :bar from foo where a = :qux";
-    final String expected = "SELECT :BAR\n"
+    final String sql = "select :bar as baz from foo where a = :qux";
+    final String expected = "SELECT :BAR AS `BAZ`\n"
         + "FROM `FOO`\n"
         + "WHERE (`A` = :QUX)";
     sql(sql).ok(expected);

--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -485,6 +485,7 @@ data: {
     includeRankWithSortingExpressions: false
     includeTopN: false
     includeInsertWithOmittedValues: false
+    includeHostVariables: false
   }
 }
 

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3861,6 +3861,10 @@ SqlNode AtomicRowExpression() :
         e = ${method}
     |
 </#list>
+<#if parser.includeHostVariables>
+        e = SqlHostVariable()
+    |
+</#if>
         e = Literal()
     |
         e = DynamicParam()

--- a/core/src/test/codegen/config.fmpp
+++ b/core/src/test/codegen/config.fmpp
@@ -468,6 +468,7 @@ data: {
     includeRankWithSortingExpressions: false
     includeTopN: false
     includeInsertWithOmittedValues: false
+    includeHostVariables: false
   }
 }
 

--- a/server/src/main/codegen/config.fmpp
+++ b/server/src/main/codegen/config.fmpp
@@ -499,6 +499,7 @@ data: {
     includeRankWithSortingExpressions: false
     includeTopN: false
     includeInsertWithOmittedValues: false
+    includeHostVariables: false
   }
 }
 


### PR DESCRIPTION
Host variables are variables prefixed with a colon (`:variableName`)