### PR TITLE
[CALCITE] DialectGenerate now parses types that contain angle brackets.

### DIFF
--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  */
 public class DialectGenerate {
 
-  private static final String type = "(\\w+\\s*(<\\s*\\w+\\s*(,\\s*\\w+\\s*)*>)?)";
+  private static final String type = "\\w+\\s*(<\\s*[\\w<>,\\s]+>)?";
   private static final String typeAndName = type + "\\s+\\w+";
   private static final String splitDelims = "(\\s|\n|\"|//|/\\*|\\*/|'|\\}|\\{)";
 

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -37,6 +37,8 @@ import java.util.regex.Pattern;
  */
 public class DialectGenerate {
 
+  // Matches foo<body> where body can be [\w\s<>,]. This allows for easy
+  // handling of nested angle brackets and comma separated values.
   private static final String type = "\\w+\\s*(<\\s*[\\w<>,\\s]+>)?";
   private static final String typeAndName = type + "\\s+\\w+";
   private static final String splitDelims = "(\\s|\n|\"|//|/\\*|\\*/|'|\\}|\\{)";
@@ -50,7 +52,8 @@ public class DialectGenerate {
   private static final Pattern functionDeclarationPattern =
     Pattern.compile("(" + typeAndName + "\\s*\\(\\s*(" + typeAndName + "\\s*(\\,\\s*"
         + typeAndName + "\\s*)*)?\\)\\s*\\:\n?)");
-  private static final Pattern namePattern = Pattern.compile("(\\w+)\\s*\\(");
+  // Matches the function name within the above function declaration.
+  private static final Pattern functionNamePattern = Pattern.compile("(\\w+)\\s*\\(");
   // Matches [<OPT1, OPT2, ...>](TOKEN|SKIP|MORE) :
   private static final Pattern tokenDeclarationPattern =
     Pattern.compile("((<\\s*\\w+\\s*(\\s*,\\s*\\w+)*\\s*>\\s*)?(TOKEN|SKIP|MORE)\\s*:\n?)");
@@ -272,7 +275,7 @@ public class DialectGenerate {
    *                            <return_type> <name> (<args>) :
    */
   public String getFunctionName(String functionDeclaration) {
-    Matcher m = namePattern.matcher(functionDeclaration);
+    Matcher m = functionNamePattern.matcher(functionDeclaration);
     m.find();
     return m.group(1);
   }

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -37,7 +37,8 @@ import java.util.regex.Pattern;
  */
 public class DialectGenerate {
 
-  private static final String typeAndName = "\\w+\\s+\\w+";
+  private static final String type = "(\\w+\\s*(<\\s*\\w+\\s*(,\\s*\\w+\\s*)*>)?)";
+  private static final String typeAndName = type + "\\s+\\w+";
   private static final String splitDelims = "(\\s|\n|\"|//|/\\*|\\*/|'|\\}|\\{)";
 
   // Used to split up a string into tokens by the specified deliminators
@@ -49,7 +50,7 @@ public class DialectGenerate {
   private static final Pattern functionDeclarationPattern =
     Pattern.compile("(" + typeAndName + "\\s*\\(\\s*(" + typeAndName + "\\s*(\\,\\s*"
         + typeAndName + "\\s*)*)?\\)\\s*\\:\n?)");
-  private static final Pattern namePattern = Pattern.compile("\\w+");
+  private static final Pattern namePattern = Pattern.compile("(\\w+)\\s*\\(");
   // Matches [<OPT1, OPT2, ...>](TOKEN|SKIP|MORE) :
   private static final Pattern tokenDeclarationPattern =
     Pattern.compile("((<\\s*\\w+\\s*(\\s*,\\s*\\w+)*\\s*>\\s*)?(TOKEN|SKIP|MORE)\\s*:\n?)");
@@ -270,11 +271,9 @@ public class DialectGenerate {
    * @param functionDeclaration The function declaration of form
    *                            <return_type> <name> (<args>) :
    */
-  private String getFunctionName(String functionDeclaration) {
+  public String getFunctionName(String functionDeclaration) {
     Matcher m = namePattern.matcher(functionDeclaration);
-    // Name is the second match.
     m.find();
-    m.find();
-    return m.group();
+    return m.group(1);
   }
 }

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
@@ -231,7 +231,7 @@ public class DialectGenerateTest {
     assertFunctionNameExtracted(declaration, "foo");
   }
 
-  @Test public void getFunctionNameSingleAngleBracketsCommaOptions() {
+  @Test public void getFunctionNameSingleAngleBracketsMultipleOptions() {
     String declaration = "Map<String, String> foo () :";
     assertFunctionNameExtracted(declaration, "foo");
   }

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
@@ -231,6 +231,11 @@ public class DialectGenerateTest {
     assertFunctionNameExtracted(declaration, "foo");
   }
 
+  @Test public void getFunctionNameNestedAngleBrackets() {
+    String declaration = "List<List<String>> foo () :";
+    assertFunctionNameExtracted(declaration, "foo");
+  }
+
   @Test public void getFunctionNameSingleAngleBracketsMultipleOptions() {
     String declaration = "Map<String, String> foo () :";
     assertFunctionNameExtracted(declaration, "foo");

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
@@ -53,6 +53,11 @@ public class DialectGenerateTest {
     assertEquals(function.length(), charIndex);
   }
 
+  private void assertFunctionNameExtracted(String declaration, String name) {
+    DialectGenerate dialectGenerate = new DialectGenerate();
+    assertEquals(name, dialectGenerate.getFunctionName(declaration));
+  }
+
   /**
    * Each testcase has a testName.txt and testName_expected.txt file.
    * This function makes sure that the testName.txt file is parsed without error
@@ -181,6 +186,10 @@ public class DialectGenerateTest {
     assertFileProcessed("functions_and_assignments");
   }
 
+  @Test public void processFileTypesWithAngleBrackets() {
+    assertFileProcessed("angle_brackets");
+  }
+
   @Test public void processTokenAssignmentTokenEmpty() {
     String declaration = "TOKEN :\n";
     String assignment = declaration
@@ -210,5 +219,25 @@ public class DialectGenerateTest {
       + "< NEGATE: \"!\" >\n"
       + "}";
     assertTokenAssignmentIsParsed(declaration, assignment);
+  }
+
+  @Test public void getFunctionNameSingleWord() {
+    String declaration = "String foo () :";
+    assertFunctionNameExtracted(declaration, "foo");
+  }
+
+  @Test public void getFunctionNameSingleAngleBrackets() {
+    String declaration = "List<String> foo () :";
+    assertFunctionNameExtracted(declaration, "foo");
+  }
+
+  @Test public void getFunctionNameSingleAngleBracketsCommaOptions() {
+    String declaration = "Map<String, String> foo () :";
+    assertFunctionNameExtracted(declaration, "foo");
+  }
+
+  @Test public void getFunctionNameWithArguments() {
+    String declaration = "Map<String, String> foo(String x, int y) :";
+    assertFunctionNameExtracted(declaration, "foo");
   }
 }

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets.txt
@@ -18,4 +18,10 @@ List<String> foo() : {} {}
 
 Map<String, String> bar() : {} {}
 
-Foo<Bar<Baz>> qux() : {} {}
+Map<List<String>, String> baz() : {} {}
+
+List   < Integer >  qux  () : {} {}
+
+void quux (List<String> x) : {} {}
+
+void corge (Map<String, Integer> x) : {} {}

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets.txt
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+List<String> foo() : {} {}
+
+Map<String, String> bar() : {} {}
+
+Foo<Bar<Baz>> qux() : {} {}

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets_expected.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets_expected.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ List<String> foo() : {} {}
+ Map<String, String> bar() : {} {}
+ Foo<Bar<Baz>> qux() : {} {}

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets_expected.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/angle_brackets/angle_brackets_expected.txt
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- List<String> foo() : {} {}
- Map<String, String> bar() : {} {}
- Foo<Bar<Baz>> qux() : {} {}
+List<String> foo() : {} {}
+Map<String, String> bar() : {} {}
+Map<List<String>, String> baz() : {} {}
+List   < Integer >  qux  () : {} {}
+void quux (List<String> x) : {} {}
+void corge (Map<String, Integer> x) : {} {}


### PR DESCRIPTION
- Added parsing support for types that contain angle brackets
- Made function name regex more robust
- Made getFunctionName() public and added tests