### PR TITLE
[CALCITE] Hex Character String Literal Rework

### DIFF
--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -472,6 +472,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/core/src/main/java/org/apache/calcite/sql/SqlHexCharStringLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlHexCharStringLiteral.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.SqlColumnAttributeCharacterSet.CharacterSet;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.parser.SqlParserUtil;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+
+import java.util.Locale;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * Parse tree for {@code SqlHexCharStringLiteral} expression.
+ */
+public class SqlHexCharStringLiteral extends SqlLiteral {
+
+  final HexCharLiteralFormat format;
+  final CharacterSet charSet;
+
+  /**
+   * Creates a {@code SqlHexCharStringLiteral}.
+   * @param hex           String that contains the hex characters
+   * @param pos           Parser position, must not be null
+   * @param charSetString Character set string, can be null
+   * @param formatString  Format of the hex char literal
+   */
+  public SqlHexCharStringLiteral(final String hex, final SqlParserPos pos,
+      final String charSetString, final String formatString) {
+    super(new NlsString(hex, null, null), SqlTypeName.CHAR, pos);
+    if (charSetString == null) {
+      this.charSet = null;
+    } else {
+      String normalizedCharSetString = SqlParserUtil
+          .trim(charSetString, " ")
+          .toUpperCase(Locale.ROOT);
+      switch (normalizedCharSetString) {
+      case "LATIN":
+        charSet = CharacterSet.LATIN;
+        break;
+      case "UNICODE":
+        charSet = CharacterSet.UNICODE;
+        break;
+      case "GRAPHIC":
+        charSet = CharacterSet.GRAPHIC;
+        break;
+      case "KANJISJIS":
+        charSet = CharacterSet.KANJISJIS;
+        break;
+      default:
+        throw SqlUtil.newContextException(pos,
+            RESOURCE.unknownCharacterSet(charSetString));
+      }
+    }
+    switch (formatString) {
+    case "XC":
+      format = HexCharLiteralFormat.XC;
+      break;
+    case "XCV":
+      format = HexCharLiteralFormat.XCV;
+      break;
+    default:
+      format = HexCharLiteralFormat.XCF;
+      break;
+    }
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec,
+      final int rightPrec) {
+    if (charSet != null) {
+      writer.print("_");
+      switch (this.charSet) {
+      case LATIN:
+        writer.keyword("LATIN");
+        break;
+      case UNICODE:
+        writer.keyword("UNICODE");
+        break;
+      case GRAPHIC:
+        writer.keyword("GRAPHIC");
+        break;
+      case KANJISJIS:
+        writer.keyword("KANJISJIS");
+        break;
+      }
+    }
+    writer.literal(value.toString());
+    switch (format) {
+    case XC:
+      writer.keyword("XC");
+      break;
+    case XCF:
+      writer.keyword("XCF");
+      break;
+    case XCV:
+      writer.keyword("XCV");
+      break;
+    }
+  }
+
+  public enum HexCharLiteralFormat {
+    /**
+     * Default format option, same as XCV.
+     */
+    XC,
+
+    /**
+     * VARCHAR format.
+     */
+    XCV,
+
+    /**
+     * CHAR format.
+     */
+    XCF,
+  }
+}

--- a/parsing/dialects/bigquery/config.fmpp
+++ b/parsing/dialects/bigquery/config.fmpp
@@ -482,6 +482,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/parsing/dialects/defaultdialect/config.fmpp
+++ b/parsing/dialects/defaultdialect/config.fmpp
@@ -482,6 +482,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -98,6 +98,8 @@ data: {
       "org.apache.calcite.sql.SqlCharacterSetToCharacterSet",
       "org.apache.calcite.sql.SqlTranslateUsingCharacterSet",
       "org.apache.calcite.sql.SqlColumnAttributeDateFormat",
+      "org.apache.calcite.sql.SqlHexCharStringLiteral",
+      "org.apache.calcite.sql.SqlHexCharStringLiteral.HexCharLiteralFormat",
       "org.apache.calcite.sql.SqlHostVariable",
     ]
 
@@ -1122,6 +1124,7 @@ data: {
     allowUpdateFromTable: true
     allowUpsertFormOfUpdate: true
     allowAbbreviatedKeywords: true
+    allowHexCharacterStringLiteral: true
     allowTranslateUsingCharSetWithError: true
     allowNestedJoins: true
     includePosixOperators: true

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1805,3 +1805,30 @@ SqlHostVariable SqlHostVariable() :
     )
     { return new SqlHostVariable(name, getPos()); }
 }
+
+SqlNode SqlHexCharStringLiteral() :
+{
+    final String hex;
+    final String formatString;
+    String charSet = null;
+}
+{
+    (
+        <PREFIXED_HEX_STRING_LITERAL>
+        {
+            charSet = SqlParserUtil.getCharacterSet(token.image);
+        }
+    |
+        <QUOTED_HEX_STRING>
+    )
+    {
+        // In the case of matching "PREFIXED_HEX_STRING_LITERAL" or
+        // "QUOTED_HEX_STRING" token, it is guaranteed that the following
+        // Java string manipulation logic is valid.
+        String[] tokens = token.image.split("'");
+        hex = tokens[1];
+        formatString = tokens[2];
+        return new SqlHexCharStringLiteral(hex, getPos(), charSet,
+            formatString);
+    }
+}

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2407,4 +2407,42 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "SELECT CAST(`X` AS BYTEINT)";
     sql(sql).ok(expected);
   }
+
+  @Test void testHexCharLiteralCharSetNotSpecifiedDefaultFormat() {
+    final String sql = "'c1a'XC";
+    final String expected = "'c1a' XC";
+    expr(sql).ok(expected);
+  }
+
+  @Test void testHexCharLiteralCharSetSpecifiedXCFormat() {
+    final String sql = "_KANJISJIS 'ABC'XC";
+    final String expected = "_KANJISJIS 'ABC' XC";
+    expr(sql).ok(expected);
+  }
+
+  @Test void testHexCharLiteralCharSetSpecifiedXCVFormat() {
+    final String sql = "_LATIN'c1a'XCV";
+    final String expected = "_LATIN 'c1a' XCV";
+    expr(sql).ok(expected);
+  }
+
+  @Test void testHexCharLiteralCharSetSpecifiedXCFFormat() {
+    final String sql = "_unicode'c1a'XCF";
+    final String expected = "_UNICODE 'c1a' XCF";
+    expr(sql).ok(expected);
+  }
+
+  @Test void testHexCharLiteralOutsideRangeFails() {
+    // 'g' contains char outside hex range, it would be incorrectly parsed
+    // falling into the <PREFIXED_STRING_LITERAL> which leads to errors
+    final String sql = "^_unicode'cg'^XCF";
+    final String expected = "Unknown character set 'unicode'";
+    expr(sql).fails(expected);
+  }
+
+  @Test void testHexCharLiteralInQuery() {
+    final String sql = "select _LATIN'c1A'XCV";
+    final String expected = "SELECT _LATIN 'c1A' XCV";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/hive/config.fmpp
+++ b/parsing/dialects/hive/config.fmpp
@@ -485,6 +485,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/parsing/dialects/mysql/config.fmpp
+++ b/parsing/dialects/mysql/config.fmpp
@@ -482,6 +482,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/parsing/dialects/postgresqlBase/dialects/postgresql/config.fmpp
+++ b/parsing/dialects/postgresqlBase/dialects/postgresql/config.fmpp
@@ -486,6 +486,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/parsing/dialects/postgresqlBase/dialects/redshift/config.fmpp
+++ b/parsing/dialects/postgresqlBase/dialects/redshift/config.fmpp
@@ -486,6 +486,7 @@ data: {
     allowUpdateFromTable: false
     allowUpsertFormOfUpdate: false
     allowAbbreviatedKeywords: false
+    allowHexCharacterStringLiteral: false
     allowTranslateUsingCharSetWithError: false
     allowNestedJoins: false
     includePosixOperators: false

--- a/parsing/src/main/resources/Parser.jj
+++ b/parsing/src/main/resources/Parser.jj
@@ -4298,6 +4298,9 @@ SqlNode StringLiteral() :
     int nfrags = 0;
     List<SqlLiteral> frags = null;
     char unicodeEscapeChar = 0;
+<#if parser.allowHexCharacterStringLiteral>
+    SqlNode hexCharLiteral;
+</#if>
 }
 {
     // A continued string literal consists of a head fragment and one or more
@@ -4306,6 +4309,11 @@ SqlNode StringLiteral() :
     // or comments may not occur between the prefix and the first quote, the
     // head fragment, with any prefix, is one token.
 
+<#if parser.allowHexCharacterStringLiteral>
+    hexCharLiteral = SqlHexCharStringLiteral()
+    { return hexCharLiteral; }
+    |
+</#if>
     <BINARY_STRING_LITERAL>
     {
         try {
@@ -7802,10 +7810,19 @@ void NonReservedKeyWord2of3() :
 |
     /* To improve error reporting, we allow all kinds of characters,
      * not just hexits, in a binary string literal. */
+<#if parser.allowHexCharacterStringLiteral>
+    < PREFIXED_HEX_STRING_LITERAL :
+    ("_" <CHARSETNAME>| "_" <CHARSETNAME> " ") <QUOTED_HEX_STRING> >
+|
+</#if>
     < BINARY_STRING_LITERAL: ["x","X"] <QUOTE> ( (~["'"]) | ("''"))* <QUOTE> >
 |
     < QUOTED_STRING: <QUOTE> ( (~["'"]) | ("''"))* <QUOTE> >
 |
+<#if parser.allowHexCharacterStringLiteral>
+    < QUOTED_HEX_STRING : <QUOTE> (<HEXDIGIT>)+ <QUOTE> (("XC") | ("XCV") | ("XCF"))>
+|
+</#if>
     < PREFIXED_STRING_LITERAL: ("_" <CHARSETNAME> | "N") <QUOTED_STRING> >
 |
     < UNICODE_STRING_LITERAL: "U" "&" <QUOTED_STRING> >


### PR DESCRIPTION
Add the ability to parse a hex character format string literal.