### PR TITLE
[CALCITE] Add support for inline CASESPECIFIC

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlCaseSpecific.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCaseSpecific.java
@@ -24,25 +24,25 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Parse tree for {@code SqlInlineCaseSpecific} statement.
+ * Parse tree for {@code SqlCaseSpecific} statement.
  */
-public class SqlInlineCaseSpecific extends SqlCall
+public class SqlCaseSpecific extends SqlCall
     implements SqlExecutableStatement {
   public static final SqlSpecialOperator OPERATOR =
-      new SqlSpecialOperator("INLINE_CASE_SPECIFIC",
-          SqlKind.INLINE_CASE_SPECIFIC);
+      new SqlSpecialOperator("CASE_SPECIFIC",
+          SqlKind.CASE_SPECIFIC);
 
   private final boolean not;
   private final SqlNode value;
 
   /**
-   * Create an {@code SqlInlineCaseSpecific}.
+   * Create an {@code SqlCaseSpecific}.
    *
    * @param pos  Parser position, must not be null
    * @param not  Specifies if NOT was parsed before CASE SPECIFIC
    * @param value  The value preceding ([NOT] CASEPECIFIC)
    */
-  public SqlInlineCaseSpecific(SqlParserPos pos, boolean not, SqlNode value) {
+  public SqlCaseSpecific(SqlParserPos pos, boolean not, SqlNode value) {
     super(pos);
     this.not = not;
     this.value = Objects.requireNonNull(value);

--- a/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
@@ -60,7 +60,7 @@ public class SqlInlineCaseSpecific extends SqlCall
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     value.unparse(writer, leftPrec, rightPrec);
     final SqlWriter.Frame frame =
-        writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+        writer.startList(SqlWriter.FrameTypeEnum.SIMPLE, "(", ")");
     if (not) {
       writer.keyword("NOT");
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
@@ -40,7 +40,7 @@ public class SqlInlineCaseSpecific extends SqlCall
    *
    * @param pos  Parser position, must not be null
    * @param not  Specifies if NOT was parsed before CASE SPECIFIC
-   * @param value  The value preceding
+   * @param value  The value preceding ([NOT] CASEPECIFIC)
    */
   public SqlInlineCaseSpecific(SqlParserPos pos, boolean not, SqlNode value) {
     super(pos);

--- a/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
@@ -16,9 +16,12 @@
  */
 package org.apache.calcite.sql;
 
+import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
 
 import java.util.Objects;
+import java.util.List;
 
 /**
  * Parse tree for {@code SqlInlineCaseSpecific} statement.
@@ -61,7 +64,7 @@ public class SqlInlineCaseSpecific extends SqlCall
     if (not) {
       writer.keyword("NOT");
     }
-    writer.keyword("CASE SPECIFIC");
+    writer.keyword("CASESPECIFIC");
     writer.endList(frame);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Objects;
+
+/**
+ * Parse tree for {@code SqlInlineCaseSpecific} statement.
+ */
+public class SqlInlineCaseSpecific extends SqlCall
+    implements SqlExecutableStatement {
+  public static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("INLINE_CASE_SPECIFIC",
+          SqlKind.INLINE_CASE_SPECIFIC);
+
+  private final boolean not;
+  private final SqlNode value;
+
+  /**
+   * Create an {@code SqlInlineCaseSpecific}.
+   *
+   * @param pos  Parser position, must not be null
+   * @param not  Specifies if NOT was parsed before CASE SPECIFIC
+   * @param value  The value preceding
+   */
+  public SqlInlineCaseSpecific(SqlParserPos pos, boolean not, SqlNode value) {
+    super(pos);
+    this.not = not;
+    this.value = Objects.requireNonNull(value);
+  }
+
+  @Override public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    // the list of paramNames could be empty
+    return ImmutableNullableList.of(value);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    value.unparse(writer, leftPrec, rightPrec);
+    final SqlWriter.Frame frame =
+        writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+    if (not) {
+      writer.keyword("NOT");
+    }
+    writer.keyword("CASE SPECIFIC");
+    writer.endList(frame);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInlineCaseSpecific.java
@@ -20,8 +20,8 @@ import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
-import java.util.Objects;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Parse tree for {@code SqlInlineCaseSpecific} statement.
@@ -53,7 +53,6 @@ public class SqlInlineCaseSpecific extends SqlCall
   }
 
   @Override public List<SqlNode> getOperandList() {
-    // the list of paramNames could be empty
     return ImmutableNullableList.of(value);
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1120,8 +1120,8 @@ public enum SqlKind {
   /** {@code DROP MATERIALIZED VIEW} DDL statement. */
   DROP_MATERIALIZED_VIEW,
 
-  /** {@code INLINE_CASE_SPECIFIC} statement. */
-  INLINE_CASE_SPECIFIC,
+  /** {@code CASE_SPECIFIC} statement. */
+  CASE_SPECIFIC,
 
   /** {@code CREATE SEQUENCE} DDL statement. */
   CREATE_SEQUENCE,

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1120,6 +1120,9 @@ public enum SqlKind {
   /** {@code DROP MATERIALIZED VIEW} DDL statement. */
   DROP_MATERIALIZED_VIEW,
 
+  /** {@code INLINE_CASE_SPECIFIC} statement. */
+  INLINE_CASE_SPECIFIC,
+
   /** {@code CREATE SEQUENCE} DDL statement. */
   CREATE_SEQUENCE,
 

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -113,6 +113,7 @@ data: {
       "CHECKSUM"
       "COMPRESS"
       "CONCURRENT"
+      "CS"
       "DATABLOCKSIZE"
       "DEL"
       "DUAL"

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -29,7 +29,6 @@ data: {
       "java.util.HashMap"
       "org.apache.calcite.sql.SqlCreate",
       "org.apache.calcite.sql.SqlCreate.SqlCreateSpecifier",
-      "org.apache.calcite.sql.SqlInlineCaseSpecific",
       "org.apache.calcite.sql.SqlColumnAttribute",
       "org.apache.calcite.sql.SqlColumnAttributeUpperCase",
       "org.apache.calcite.sql.SqlColumnAttributeCaseSpecific",
@@ -57,6 +56,7 @@ data: {
       "org.apache.calcite.sql.SqlSetTimeZone",
       "org.apache.calcite.sql.OnCommitType",
       "org.apache.calcite.sql.SetType",
+      "org.apache.calcite.sql.SqlInlineCaseSpecific",
       "org.apache.calcite.sql.SqlTableAttribute",
       "org.apache.calcite.sql.SqlTableAttributeBlockCompression",
       "org.apache.calcite.sql.SqlTableAttributeBlockCompression.BlockCompressionOption",

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -56,7 +56,7 @@ data: {
       "org.apache.calcite.sql.SqlSetTimeZone",
       "org.apache.calcite.sql.OnCommitType",
       "org.apache.calcite.sql.SetType",
-      "org.apache.calcite.sql.SqlInlineCaseSpecific",
+      "org.apache.calcite.sql.SqlCaseSpecific",
       "org.apache.calcite.sql.SqlTableAttribute",
       "org.apache.calcite.sql.SqlTableAttributeBlockCompression",
       "org.apache.calcite.sql.SqlTableAttributeBlockCompression.BlockCompressionOption",

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -29,6 +29,7 @@ data: {
       "java.util.HashMap"
       "org.apache.calcite.sql.SqlCreate",
       "org.apache.calcite.sql.SqlCreate.SqlCreateSpecifier",
+      "org.apache.calcite.sql.SqlInlineCaseSpecific",
       "org.apache.calcite.sql.SqlColumnAttribute",
       "org.apache.calcite.sql.SqlColumnAttributeUpperCase",
       "org.apache.calcite.sql.SqlColumnAttributeCaseSpecific",
@@ -1095,6 +1096,7 @@ data: {
     ]
 
     preExpressionMethods: [
+      "InlineCaseSpecific"
       "InlineModOperator"
       "AlternativeTypeConversionLiteralOrIdentifier"
       "InlineFormatLiteralOrIdentifier"

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -1097,6 +1097,7 @@ data: {
 
     preExpressionMethods: [
       "InlineCaseSpecific"
+      "InlineCaseSpecificNamedFunctionCall"
       "InlineModOperator"
       "AlternativeTypeConversionLiteralOrIdentifier"
       "InlineFormatLiteralOrIdentifier"

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1795,7 +1795,7 @@ SqlNode SqlSelectTopN(SqlParserPos pos) :
 SqlNode InlineCaseSpecific() :
 {
     final SqlNode value;
-    boolean not = false;
+    final SqlCaseSpecific caseSpecific;
 }
 {
     (
@@ -1804,9 +1804,9 @@ SqlNode InlineCaseSpecific() :
         LOOKAHEAD( CompoundIdentifier() CaseSpecific() )
         value = CompoundIdentifier()
     )
-    not = CaseSpecific()
+    caseSpecific = CaseSpecific(value)
     {
-        return new SqlCaseSpecific(getPos(), not, value);
+        return caseSpecific;
     }
 }
 
@@ -1817,17 +1817,17 @@ SqlNode InlineCaseSpecific() :
 SqlNode InlineCaseSpecificNamedFunctionCall() :
 {
     final SqlNode value;
-    boolean not = false;
+    final SqlCaseSpecific caseSpecific;
 }
 {
     value = NamedFunctionCall()
-    not = CaseSpecific()
+    caseSpecific = CaseSpecific(value)
     {
-        return new SqlCaseSpecific(getPos(), not, value);
+        return caseSpecific;
     }
 }
 
-boolean CaseSpecific() :
+SqlCaseSpecific CaseSpecific(SqlNode value) :
 {
     boolean not = false;
 }
@@ -1841,7 +1841,7 @@ boolean CaseSpecific() :
     )
     <RPAREN>
     {
-        return not;
+        return new SqlCaseSpecific(getPos(), not, value);
     }
 }
 

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1801,16 +1801,10 @@ SqlNode InlineCaseSpecific() :
     (
         value = StringLiteral()
     |
-        // Required to differentiate between this and CompoundIdentifier().
-        LOOKAHEAD([<SPECIFIC>] FunctionName() <LPAREN>,
-        {
-            // Token index breakdown:
-            // NAME(1) <LPAREN>(2) [<NOT>](3) <CASEPECIFIC>(3 or 4) <RPAREN>(4 or 5)
-            getToken(3).kind != NOT && getToken(4).kind != CASESPECIFIC && getToken(3).kind != CASESPECIFIC
-        })
-        value = NamedFunctionCall()
-    |
+        LOOKAHEAD( CompoundIdentifier() <LPAREN> [<NOT>] <CASESPECIFIC> <RPAREN> )
         value = CompoundIdentifier()
+    |
+        value = NamedFunctionCall()
     )
     <LPAREN>
     [ <NOT> { not = true; } ]

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1802,7 +1802,12 @@ SqlNode InlineCaseSpecific() :
         value = StringLiteral()
     |
         // Required to differentiate between this and CompoundIdentifier().
-        LOOKAHEAD( [<SPECIFIC>] FunctionName() <LPAREN> )
+        LOOKAHEAD([<SPECIFIC>] FunctionName() <LPAREN>,
+        {
+            // Token index breakdown:
+            // NAME(1) <LPAREN>(2) [<NOT>](3) <CASEPECIFIC>(3 or 4) <RPAREN>(4 or 5)
+            getToken(3).kind != NOT && getToken(4).kind != CASESPECIFIC && getToken(3).kind != CASESPECIFIC
+        })
         value = NamedFunctionCall()
     |
         value = CompoundIdentifier()

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1792,6 +1792,22 @@ SqlNode SqlSelectTopN(SqlParserPos pos) :
     }
 }
 
+SqlNode InlineCaseSpecificNamedFunctionCall() :
+{
+    SqlNode value;
+    boolean not = false;
+}
+{
+    value = NamedFunctionCall()
+    <LPAREN>
+    [ <NOT> { not = true; } ]
+    <CASESPECIFIC>
+    <RPAREN>
+    {
+        return new SqlInlineCaseSpecific(getPos(), not, value);
+    }
+}
+
 SqlNode InlineCaseSpecific() :
 {
     SqlNode value;
@@ -1803,8 +1819,6 @@ SqlNode InlineCaseSpecific() :
     |
         LOOKAHEAD( CompoundIdentifier() <LPAREN> [<NOT>] <CASESPECIFIC> <RPAREN> )
         value = CompoundIdentifier()
-    |
-        value = NamedFunctionCall()
     )
     <LPAREN>
     [ <NOT> { not = true; } ]
@@ -1813,7 +1827,6 @@ SqlNode InlineCaseSpecific() :
     {
         return new SqlInlineCaseSpecific(getPos(), not, value);
     }
-
 }
 
 SqlHostVariable SqlHostVariable() :

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1792,22 +1792,6 @@ SqlNode SqlSelectTopN(SqlParserPos pos) :
     }
 }
 
-SqlNode InlineCaseSpecificNamedFunctionCall() :
-{
-    SqlNode value;
-    boolean not = false;
-}
-{
-    value = NamedFunctionCall()
-    <LPAREN>
-    [ <NOT> { not = true; } ]
-    <CASESPECIFIC>
-    <RPAREN>
-    {
-        return new SqlInlineCaseSpecific(getPos(), not, value);
-    }
-}
-
 SqlNode InlineCaseSpecific() :
 {
     SqlNode value;
@@ -1820,6 +1804,26 @@ SqlNode InlineCaseSpecific() :
         LOOKAHEAD( CompoundIdentifier() <LPAREN> [<NOT>] <CASESPECIFIC> <RPAREN> )
         value = CompoundIdentifier()
     )
+    <LPAREN>
+    [ <NOT> { not = true; } ]
+    <CASESPECIFIC>
+    <RPAREN>
+    {
+        return new SqlInlineCaseSpecific(getPos(), not, value);
+    }
+}
+
+/* This has to be separate from the InlineCaseSpecific() due to the LOOKAHEAD
+   for preExpressionMethods in Parser.jj breaking if both CompoundIdentifier()
+   and NamedFunctionCall() are options.
+ */
+SqlNode InlineCaseSpecificNamedFunctionCall() :
+{
+    SqlNode value;
+    boolean not = false;
+}
+{
+    value = NamedFunctionCall()
     <LPAREN>
     [ <NOT> { not = true; } ]
     <CASESPECIFIC>

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1794,19 +1794,23 @@ SqlNode SqlSelectTopN(SqlParserPos pos) :
 
 SqlNode InlineCaseSpecific() :
 {
-    SqlNode value;
+    final SqlNode value;
     boolean not = false;
 }
 {
     (
         value = StringLiteral()
     |
-        LOOKAHEAD( CompoundIdentifier() <LPAREN> [ <NOT> ] <CASESPECIFIC> <RPAREN> )
+        LOOKAHEAD( CompoundIdentifier() <LPAREN> [ <NOT> ] (<CASESPECIFIC>|<CS>) <RPAREN> )
         value = CompoundIdentifier()
     )
     <LPAREN>
     [ <NOT> { not = true; } ]
-    <CASESPECIFIC>
+    (
+        <CASESPECIFIC>
+    |
+        <CS>
+    )
     <RPAREN>
     {
         return new SqlInlineCaseSpecific(getPos(), not, value);
@@ -1819,14 +1823,18 @@ SqlNode InlineCaseSpecific() :
  */
 SqlNode InlineCaseSpecificNamedFunctionCall() :
 {
-    SqlNode value;
+    final SqlNode value;
     boolean not = false;
 }
 {
     value = NamedFunctionCall()
     <LPAREN>
     [ <NOT> { not = true; } ]
-    <CASESPECIFIC>
+    (
+        <CASESPECIFIC>
+    |
+        <CS>
+    )
     <RPAREN>
     {
         return new SqlInlineCaseSpecific(getPos(), not, value);

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1801,19 +1801,12 @@ SqlNode InlineCaseSpecific() :
     (
         value = StringLiteral()
     |
-        LOOKAHEAD( CompoundIdentifier() <LPAREN> [ <NOT> ] (<CASESPECIFIC>|<CS>) <RPAREN> )
+        LOOKAHEAD( CompoundIdentifier() CaseSpecific() )
         value = CompoundIdentifier()
     )
-    <LPAREN>
-    [ <NOT> { not = true; } ]
-    (
-        <CASESPECIFIC>
-    |
-        <CS>
-    )
-    <RPAREN>
+    not = CaseSpecific()
     {
-        return new SqlInlineCaseSpecific(getPos(), not, value);
+        return new SqlCaseSpecific(getPos(), not, value);
     }
 }
 
@@ -1828,6 +1821,17 @@ SqlNode InlineCaseSpecificNamedFunctionCall() :
 }
 {
     value = NamedFunctionCall()
+    not = CaseSpecific()
+    {
+        return new SqlCaseSpecific(getPos(), not, value);
+    }
+}
+
+boolean CaseSpecific() :
+{
+    boolean not = false;
+}
+{
     <LPAREN>
     [ <NOT> { not = true; } ]
     (
@@ -1837,7 +1841,7 @@ SqlNode InlineCaseSpecificNamedFunctionCall() :
     )
     <RPAREN>
     {
-        return new SqlInlineCaseSpecific(getPos(), not, value);
+        return not;
     }
 }
 

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1792,6 +1792,31 @@ SqlNode SqlSelectTopN(SqlParserPos pos) :
     }
 }
 
+SqlNode InlineCaseSpecific() :
+{
+    SqlNode value;
+    boolean not = false;
+}
+{
+    (
+        value = StringLiteral()
+    |
+        // Required to differentiate between this and CompoundIdentifier().
+        LOOKAHEAD( [<SPECIFIC>] FunctionName() <LPAREN> )
+        value = NamedFunctionCall()
+    |
+        value = CompoundIdentifier()
+    )
+    <LPAREN>
+    [ <NOT> { not = true; } ]
+    <CASESPECIFIC>
+    <RPAREN>
+    {
+        return new SqlInlineCaseSpecific(getPos(), not, value);
+    }
+
+}
+
 SqlHostVariable SqlHostVariable() :
 {
     final String name;

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1801,7 +1801,7 @@ SqlNode InlineCaseSpecific() :
     (
         value = StringLiteral()
     |
-        LOOKAHEAD( CompoundIdentifier() <LPAREN> [<NOT>] <CASESPECIFIC> <RPAREN> )
+        LOOKAHEAD( CompoundIdentifier() <LPAREN> [ <NOT> ] <CASESPECIFIC> <RPAREN> )
         value = CompoundIdentifier()
     )
     <LPAREN>

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2352,7 +2352,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String sql = "select * from foo where a = 'Hello' (casespecific)";
     final String expected = "SELECT *\n"
      + "FROM `FOO`\n"
-     + "WHERE (`A` = 'Hello'(CASESPECIFIC))";
+     + "WHERE (`A` = 'Hello' (CASESPECIFIC))";
     sql(sql).ok(expected);
   }
 
@@ -2360,7 +2360,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (not casespecific)";
     final String expected = "SELECT *\n"
      + "FROM `FOO`\n"
-     + "WHERE (`A` = 'Hello'(CASESPECIFIC))";
+     + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (NOT CASESPECIFIC))";
     sql(sql).ok(expected);
   }
 
@@ -2368,18 +2368,25 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (casespecific)";
     final String expected = "SELECT *\n"
      + "FROM `FOO`\n"
-     + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello'(CASESPECIFIC))";
+     + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (CASESPECIFIC))";
     sql(sql).ok(expected);
   }
 
-  /*@Test public void testInlineCaseSpecificFunctionCall() {
+  @Test public void testInlineCaseSpecificFunctionCall() {
     final String sql = "select * from foo where MY_FUN(a) (CASESPECIFIC) = 'Hello'";
     final String expected = "SELECT *\n"
      + "FROM `FOO`\n"
      + "WHERE (MY_FUN(a) (CASESPECIFIC) = 'Hello')";
     sql(sql).ok(expected);
-  }*/
+  }
 
+  @Test public void testInlineCaseSpecificCompoundIdentifier() {
+    final String sql = "select * from foo as f where f.a (casespecific) = 'Hello'";
+    final String expected = "SELECT *\n"
+     + "FROM `FOO` AS `F`\n"
+     + "WHERE ( `F`.`A` (CASESPECIFIC) = 'Hello')";
+    sql(sql).ok(expected);
+  }
   @Test public void testHostVariableExecPositionalParams() {
     final String sql = "exec foo (:bar, :baz, :qux)";
     final String expected = "EXECUTE `FOO` (:BAR, :BAZ, :QUX)";

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2365,7 +2365,8 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
   }
 
   @Test public void testInlineCaseSpecificNotCaseSpecificEqualsNotCaseSpecific() {
-    final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (not casespecific)";
+    final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello'"
+        + " (not casespecific)";
     final String expected = "SELECT *\n"
         + "FROM `FOO`\n"
         + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (NOT CASESPECIFIC))";

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2387,6 +2387,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
      + "WHERE (`F`.`A` (CASESPECIFIC) = 'Hello')";
     sql(sql).ok(expected);
   }
+
   @Test public void testHostVariableExecPositionalParams() {
     final String sql = "exec foo (:bar, :baz, :qux)";
     final String expected = "EXECUTE `FOO` (:BAR, :BAZ, :QUX)";

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2348,6 +2348,38 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).fails(expected);
   }
 
+  @Test public void testInlineCaseSpecificNoneEqualsCaseSpecific() {
+    final String sql = "select * from foo where a = 'Hello' (casespecific)";
+    final String expected = "SELECT *\n"
+     + "FROM `FOO`\n"
+     + "WHERE (`A` = 'Hello'(CASESPECIFIC))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testInlineCaseSpecificNotCaseSpecificEqualsNotCaseSpecific() {
+    final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (not casespecific)";
+    final String expected = "SELECT *\n"
+     + "FROM `FOO`\n"
+     + "WHERE (`A` = 'Hello'(CASESPECIFIC))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testInlineCaseSpecificNotCaseSpecificEqualsCaseSpecific() {
+    final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (casespecific)";
+    final String expected = "SELECT *\n"
+     + "FROM `FOO`\n"
+     + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello'(CASESPECIFIC))";
+    sql(sql).ok(expected);
+  }
+
+  /*@Test public void testInlineCaseSpecificFunctionCall() {
+    final String sql = "select * from foo where MY_FUN(a) (CASESPECIFIC) = 'Hello'";
+    final String expected = "SELECT *\n"
+     + "FROM `FOO`\n"
+     + "WHERE (MY_FUN(a) (CASESPECIFIC) = 'Hello')";
+    sql(sql).ok(expected);
+  }*/
+
   @Test public void testHostVariableExecPositionalParams() {
     final String sql = "exec foo (:bar, :baz, :qux)";
     final String expected = "EXECUTE `FOO` (:BAR, :BAZ, :QUX)";

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2348,43 +2348,51 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).fails(expected);
   }
 
+  @Test public void testInlineCaseSpecificAbbreviated() {
+    final String sql = "select * from foo where a (not cs) = 'Hello' (cs)";
+    final String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (CASESPECIFIC))";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testInlineCaseSpecificNoneEqualsCaseSpecific() {
     final String sql = "select * from foo where a = 'Hello' (casespecific)";
     final String expected = "SELECT *\n"
-     + "FROM `FOO`\n"
-     + "WHERE (`A` = 'Hello' (CASESPECIFIC))";
+        + "FROM `FOO`\n"
+        + "WHERE (`A` = 'Hello' (CASESPECIFIC))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineCaseSpecificNotCaseSpecificEqualsNotCaseSpecific() {
     final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (not casespecific)";
     final String expected = "SELECT *\n"
-     + "FROM `FOO`\n"
-     + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (NOT CASESPECIFIC))";
+        + "FROM `FOO`\n"
+        + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (NOT CASESPECIFIC))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineCaseSpecificNotCaseSpecificEqualsCaseSpecific() {
     final String sql = "select * from foo where a (NOT CASESPECIFIC) = 'Hello' (casespecific)";
     final String expected = "SELECT *\n"
-     + "FROM `FOO`\n"
-     + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (CASESPECIFIC))";
+        + "FROM `FOO`\n"
+        + "WHERE (`A` (NOT CASESPECIFIC) = 'Hello' (CASESPECIFIC))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineCaseSpecificFunctionCall() {
     final String sql = "select * from foo where MY_FUN(a) (CASESPECIFIC) = 'Hello'";
     final String expected = "SELECT *\n"
-     + "FROM `FOO`\n"
-     + "WHERE (`MY_FUN`(`A`) (CASESPECIFIC) = 'Hello')";
+        + "FROM `FOO`\n"
+        + "WHERE (`MY_FUN`(`A`) (CASESPECIFIC) = 'Hello')";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineCaseSpecificCompoundIdentifier() {
     final String sql = "select * from foo as f where f.a (casespecific) = 'Hello'";
     final String expected = "SELECT *\n"
-     + "FROM `FOO` AS `F`\n"
-     + "WHERE (`F`.`A` (CASESPECIFIC) = 'Hello')";
+        + "FROM `FOO` AS `F`\n"
+        + "WHERE (`F`.`A` (CASESPECIFIC) = 'Hello')";
     sql(sql).ok(expected);
   }
 

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2376,7 +2376,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String sql = "select * from foo where MY_FUN(a) (CASESPECIFIC) = 'Hello'";
     final String expected = "SELECT *\n"
      + "FROM `FOO`\n"
-     + "WHERE (MY_FUN(a) (CASESPECIFIC) = 'Hello')";
+     + "WHERE (`MY_FUN`(`A`) (CASESPECIFIC) = 'Hello')";
     sql(sql).ok(expected);
   }
 

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2384,7 +2384,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String sql = "select * from foo as f where f.a (casespecific) = 'Hello'";
     final String expected = "SELECT *\n"
      + "FROM `FOO` AS `F`\n"
-     + "WHERE ( `F`.`A` (CASESPECIFIC) = 'Hello')";
+     + "WHERE (`F`.`A` (CASESPECIFIC) = 'Hello')";
     sql(sql).ok(expected);
   }
   @Test public void testHostVariableExecPositionalParams() {


### PR DESCRIPTION
- Added java class for unparsing
- Added two functions for parsing in dialect1's parserImpls (can't combine them due to lookahead issues)
- Added tests for dialect1