### PR TITLE
[CALCITE] Add support for VARBYTE and BYTE data types

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -104,6 +104,10 @@ public enum SqlTypeName {
       SqlTypeFamily.BINARY),
   VARBINARY(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY,
       SqlTypeFamily.BINARY),
+  VARBYTE(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY,
+      SqlTypeFamily.BINARY),
+  BYTE(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.VARBINARY,
+      SqlTypeFamily.BINARY),
   NULL(PrecScale.NO_NO, true, Types.NULL, SqlTypeFamily.NULL),
   ANY(PrecScale.NO_NO | PrecScale.YES_NO | PrecScale.YES_YES, true,
       Types.JAVA_OBJECT, SqlTypeFamily.ANY),
@@ -147,7 +151,7 @@ public enum SqlTypeName {
   public static final List<SqlTypeName> ALL_TYPES =
       ImmutableList.of(
           BOOLEAN, INTEGER, VARCHAR, DATE, TIME, TIMESTAMP, NULL, DECIMAL,
-          ANY, CHAR, BINARY, VARBINARY, TINYINT, SMALLINT, BIGINT, BYTEINT, REAL,
+          ANY, CHAR, BINARY, VARBINARY, VARBYTE, BYTE, TINYINT, SMALLINT, BIGINT, BYTEINT, REAL,
           DOUBLE, SYMBOL, INTERVAL_YEAR, INTERVAL_YEAR_MONTH, INTERVAL_MONTH,
           INTERVAL_DAY, INTERVAL_DAY_HOUR, INTERVAL_DAY_MINUTE,
           INTERVAL_DAY_SECOND, INTERVAL_HOUR, INTERVAL_HOUR_MINUTE,
@@ -159,7 +163,7 @@ public enum SqlTypeName {
       ImmutableList.of(BOOLEAN);
 
   public static final List<SqlTypeName> BINARY_TYPES =
-      ImmutableList.of(BINARY, VARBINARY);
+      ImmutableList.of(BINARY, VARBINARY, VARBYTE, BYTE);
 
   public static final List<SqlTypeName> INT_TYPES =
       ImmutableList.of(TINYINT, SMALLINT, INTEGER, BIGINT, BYTEINT);
@@ -575,6 +579,8 @@ public enum SqlTypeName {
 
     case BINARY:
     case VARBINARY:
+    case VARBYTE:
+    case BYTE:
       if (!sign) {
         return null; // this type does not have negative values
       }
@@ -746,6 +752,8 @@ public enum SqlTypeName {
     case CHAR:
     case VARBINARY:
     case BINARY:
+    case VARBYTE:
+    case BYTE:
     case TIME:
     case TIME_WITH_LOCAL_TIME_ZONE:
     case TIMESTAMP:
@@ -923,6 +931,8 @@ public enum SqlTypeName {
       return SqlLiteral.createCharString((String) o, pos);
     case VARBINARY:
     case BINARY:
+    case VARBYTE:
+    case BYTE:
       return SqlLiteral.createBinaryString((byte[]) o, pos);
     case DATE:
       return SqlLiteral.createDate(o instanceof Calendar

--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -271,7 +271,7 @@ class CalciteRemoteDriverTest {
   @Test void testRemoteTypeInfo() throws Exception {
     CalciteAssert.hr().with(REMOTE_CONNECTION_FACTORY)
         .metaData(GET_TYPEINFO)
-        .returns(CalciteAssert.checkResultCount(is(46)));
+        .returns(CalciteAssert.checkResultCount(is(48)));
   }
 
   @Test void testRemoteTableTypes() throws Exception {

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -106,6 +106,7 @@ data: {
       "ARCHIVE"
       "AUTOTEMP"
       "BLOCKCOMPRESSION"
+      "BYTE"
       "BYTEINT"
       "BYTES"
       "CASESPECIFIC"
@@ -153,6 +154,7 @@ data: {
       "UNICODE"
       "UPD"
       "UPPERCASE"
+      "VARBYTE"
       "VIRTUAL"
       "VOLATILE"
     ]
@@ -476,6 +478,7 @@ data: {
       "ARCHIVE"
       "AUTOTEMP"
       "BLOCKCOMPRESSION"
+      "BYTE"
       "BYTES"
       "CHECKSUM"
       "CONCURRENT"
@@ -511,6 +514,7 @@ data: {
       "STORED"
       "UNICODE"
       "UPD"
+      "VARBYTE"
       "VIRTUAL"
 
       # The following keywords are reserved in core Calcite,
@@ -1009,7 +1013,9 @@ data: {
     # Return type of method implementation should be "SqlTypeNameSpec".
     # Example: SqlParseTimeStampZ().
     dataTypeParserMethods: [
+      "ByteDataType()"
       "ByteIntType()"
+      "VarbyteDataType()"
     ]
 
     # List of methods for parsing builtin function calls.

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1805,3 +1805,48 @@ SqlHostVariable SqlHostVariable() :
     )
     { return new SqlHostVariable(name, getPos()); }
 }
+
+SqlTypeNameSpec ByteDataType() :
+{
+    final SqlTypeName sqlTypeName;
+    final Span s = Span.of();
+    int precision = -1;
+}
+{
+    <BYTE> { sqlTypeName = SqlTypeName.BYTE; }
+    [ precision = VariableBinaryTypePrecision() ]
+    {
+        return new SqlBasicTypeNameSpec(sqlTypeName, precision, s.end(this));
+    }
+}
+
+SqlTypeNameSpec VarbyteDataType() :
+{
+    final SqlTypeName sqlTypeName;
+    final Span s = Span.of();
+    final int precision;
+}
+{
+    <VARBYTE> { sqlTypeName = SqlTypeName.VARBYTE; }
+    precision = VariableBinaryTypePrecision()
+    {
+        return new SqlBasicTypeNameSpec(sqlTypeName, precision, s.end(this));
+    }
+}
+
+int VariableBinaryTypePrecision() :
+{
+    final int precision;
+}
+{
+    <LPAREN>
+    precision = UnsignedIntLiteral()
+    {
+        if (precision > 64000) {
+            throw SqlUtil.newContextException(getPos(),
+                RESOURCE.numberLiteralOutOfRange(String.valueOf(precision)));
+        }
+    }
+    <RPAREN>
+    { return precision; }
+}

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1808,29 +1808,27 @@ SqlHostVariable SqlHostVariable() :
 
 SqlTypeNameSpec ByteDataType() :
 {
-    final SqlTypeName sqlTypeName;
     final Span s = Span.of();
     int precision = -1;
 }
 {
-    <BYTE> { sqlTypeName = SqlTypeName.BYTE; }
+    <BYTE>
     [ precision = VariableBinaryTypePrecision() ]
     {
-        return new SqlBasicTypeNameSpec(sqlTypeName, precision, s.end(this));
+        return new SqlBasicTypeNameSpec(SqlTypeName.BYTE, precision, s.end(this));
     }
 }
 
 SqlTypeNameSpec VarbyteDataType() :
 {
-    final SqlTypeName sqlTypeName;
     final Span s = Span.of();
     final int precision;
 }
 {
-    <VARBYTE> { sqlTypeName = SqlTypeName.VARBYTE; }
+    <VARBYTE>
     precision = VariableBinaryTypePrecision()
     {
-        return new SqlBasicTypeNameSpec(sqlTypeName, precision, s.end(this));
+        return new SqlBasicTypeNameSpec(SqlTypeName.VARBYTE, precision, s.end(this));
     }
 }
 

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2407,4 +2407,70 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "SELECT CAST(`X` AS BYTEINT)";
     sql(sql).ok(expected);
   }
+
+  @Test public void testVarbyte() {
+    final String sql = "create table foo (bar varbyte(20))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` VARBYTE(20))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testVarbyteMaxValue() {
+    final String sql = "create table foo (bar varbyte(64000))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` VARBYTE(64000))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testVarbyteCast() {
+    final String sql = "select cast(foo as varbyte(100))";
+    final String expected = "SELECT CAST(`FOO` AS VARBYTE(100))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testVarbyteOutOfRangeFails() {
+    final String sql = "create table foo (bar varbyte(^64001^))";
+    final String expected = "(?s).*Numeric literal.*out of range.*";
+    sql(sql).fails(expected);
+  }
+
+  @Test public void testVarbyteNegativeFails() {
+    final String sql = "create table foo (bar varbyte(^-^1))";
+    final String expected = "(?s).*Encountered \"-\" at .*";
+    sql(sql).fails(expected);
+  }
+
+  @Test public void testByte() {
+    final String sql = "create table foo (bar byte)";
+    final String expected = "CREATE TABLE `FOO` (`BAR` BYTE)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testByteWithValue() {
+    final String sql = "create table foo (bar byte(20))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` BYTE(20))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testByteMaxValue() {
+    final String sql = "create table foo (bar byte(64000))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` BYTE(64000))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testByteCast() {
+    final String sql = "select cast(foo as byte(100))";
+    final String expected = "SELECT CAST(`FOO` AS BYTE(100))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testByteOutOfRangeFails() {
+    final String sql = "create table foo (bar byte(^64001^))";
+    final String expected = "(?s).*Numeric literal.*out of range.*";
+    sql(sql).fails(expected);
+  }
+
+  @Test public void testByteNegativeFails() {
+    final String sql = "create table foo (bar byte^(^-1))";
+    final String expected = "(?s).*Encountered \"\\( -\" at .*";
+    sql(sql).fails(expected);
+  }
 }


### PR DESCRIPTION
VARBYTE syntax: `VARBYTE\(n\)`
BYTE syntax: `BYTE[\(n\)]`