### PR TITLE
[CALCITE] Support functions in alternative CAST, inline FORMAT, and NAMED expression

### DIFF
--- a/core/src/main/codegen/config.fmpp
+++ b/core/src/main/codegen/config.fmpp
@@ -487,6 +487,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/dialects/bigquery/config.fmpp
+++ b/parsing/dialects/bigquery/config.fmpp
@@ -497,6 +497,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/dialects/defaultdialect/config.fmpp
+++ b/parsing/dialects/defaultdialect/config.fmpp
@@ -497,6 +497,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -1157,6 +1157,7 @@ data: {
     includeTopN: true
     includeInsertWithOmittedValues: true
     includeHostVariables: true
+    includePostExpressionMethodsAfterFunction: true
   }
 }
 

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2407,4 +2407,22 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "SELECT CAST(`X` AS BYTEINT)";
     sql(sql).ok(expected);
   }
+
+  @Test void testAlternativeTypeConversionWithNamedFunction() {
+    final String sql = "SELECT foo(a) (INT)";
+    final String expected = "SELECT CAST(`FOO`(`A`) AS INTEGER)";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testInlineFormatWithNamedFunction() {
+    final String sql = "select foo(a) (format 'X6')";
+    final String expected = "SELECT (`FOO`(`A`) (FORMAT 'X6'))";
+    sql(sql).ok(expected);
+  }
+
+  @Test void testInlinNamedWithNamedFunction() {
+    final String sql = "select foo(a) (named b)";
+    final String expected = "SELECT `FOO`(`A`) AS `B`";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2524,7 +2524,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
-  @Test void testInlinNamedWithNamedFunction() {
+  @Test void testNamedExpressionWithNamedFunction() {
     final String sql = "select foo(a) (named b)";
     final String expected = "SELECT `FOO`(`A`) AS `B`";
     sql(sql).ok(expected);

--- a/parsing/dialects/hive/config.fmpp
+++ b/parsing/dialects/hive/config.fmpp
@@ -500,6 +500,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/dialects/mysql/config.fmpp
+++ b/parsing/dialects/mysql/config.fmpp
@@ -497,6 +497,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/dialects/postgresqlBase/dialects/postgresql/config.fmpp
+++ b/parsing/dialects/postgresqlBase/dialects/postgresql/config.fmpp
@@ -501,6 +501,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/dialects/postgresqlBase/dialects/redshift/config.fmpp
+++ b/parsing/dialects/postgresqlBase/dialects/redshift/config.fmpp
@@ -501,6 +501,7 @@ data: {
     includeTopN: false
     includeInsertWithOmittedValues: false
     includeHostVariables: false
+    includePostExpressionMethodsAfterFunction: false
   }
 }
 

--- a/parsing/src/main/resources/Parser.jj
+++ b/parsing/src/main/resources/Parser.jj
@@ -6524,6 +6524,7 @@ SqlNode NamedFunctionCall() :
     SqlLiteral quantifier = null;
     SqlNodeList orderList = null;
     final Span withinGroupSpan;
+    SqlNode e;
 }
 {
     (
@@ -6581,9 +6582,13 @@ SqlNode NamedFunctionCall() :
             call = SqlStdOperatorTable.OVER.createCall(s.end(over), call, over);
         }
     ]
-    {
-        return call;
-    }
+    (
+<#list parser.postExpressionMethods as method>
+        e = ${method}(call) { return e; }
+    |
+</#list>
+        { return call; }
+    )
 }
 
 

--- a/parsing/src/main/resources/Parser.jj
+++ b/parsing/src/main/resources/Parser.jj
@@ -6591,10 +6591,12 @@ SqlNode NamedFunctionCall() :
         }
     ]
     (
+<#if parser.includePostExpressionMethodsAfterFunction>
 <#list parser.postExpressionMethods as method>
         e = ${method}(call) { return e; }
     |
 </#list>
+</#if>
         { return call; }
     )
 }

--- a/parsing/src/main/resources/Parser.jj
+++ b/parsing/src/main/resources/Parser.jj
@@ -6532,7 +6532,9 @@ SqlNode NamedFunctionCall() :
     SqlLiteral quantifier = null;
     SqlNodeList orderList = null;
     final Span withinGroupSpan;
+<#if parser.includePostExpressionMethodsAfterFunction>
     SqlNode e;
+</#if>
 }
 {
     (


### PR DESCRIPTION
This adds support for functions not wrapped in outer parentheses