### PR TITLE
[CALCITE] Add support for Sql PERIOD type

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -59,7 +59,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
       }
       this.precision = precisionValue;
     } else {
-      if (timeScale == TimeScale.DATE){
+      if (timeScale == TimeScale.DATE) {
         this.precision = null;
       } else {
         this.precision = PRECISION_DEFAULT;

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.calcite.sql;
 
 import org.apache.calcite.rel.type.RelDataType;

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -32,16 +32,19 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
   public final Integer precision;
   public final boolean isWithTimezone;
 
+  private static final int PRECISION_UPPERBOUND = 6;
+  private static final int PRECISION_DEFAULT = 6;
+
   public SqlPeriodTypeNameSpec(TimeScale timeScale,
       SqlNumericLiteral precision,
       boolean isWithTimezone, SqlParserPos pos) {
     super(new SqlIdentifier("Period", pos), pos);
 
-    // date period cannot contain precision or with time zone token
+    // Date period cannot contain precision or with time zone token.
     if (timeScale == TimeScale.DATE
-        && (precision != null || isWithTimezone)) {
-      throw SqlUtil.newContextException(pos,
-          RESOURCE.illegalNonQueryExpression());
+        && precision != null || isWithTimezone) {
+          throw SqlUtil.newContextException(pos,
+              RESOURCE.illegalNonQueryExpression());
     }
 
     if (precision != null) {
@@ -50,13 +53,17 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
             RESOURCE.illegalNonQueryExpression());
       }
       int precisionValue = Integer.parseInt(precision.toValue());
-      if (precisionValue < 0 || precisionValue > 6) {
+      if (precisionValue < 0 || precisionValue > PRECISION_UPPERBOUND) {
         throw SqlUtil.newContextException(pos,
             RESOURCE.numberLiteralOutOfRange("Precision"));
       }
       this.precision = precisionValue;
     } else {
-      this.precision = null;
+      if (timeScale == TimeScale.DATE){
+        this.precision = null;
+      } else {
+        this.precision = PRECISION_DEFAULT;
+      }
     }
     this.timeScale = timeScale;
     this.isWithTimezone = isWithTimezone;
@@ -85,18 +92,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
   }
 
   @Override public boolean equalsDeep(final SqlTypeNameSpec spec, final Litmus litmus) {
-    if (!(spec instanceof SqlPeriodTypeNameSpec)) {
-      return litmus.fail("{} != {}", this, spec);
-    }
-
-    SqlPeriodTypeNameSpec that = (SqlPeriodTypeNameSpec) spec;
-
-    // two period types are the same as long as their time scales are the same
-    if (this.timeScale != that.timeScale) {
-      return litmus.fail("{} != {}", this, spec);
-    }
-
-    return litmus.succeed();
+    return false; // Since there is no test for this method, it is left blank.
   }
 
   public enum TimeScale {

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -28,15 +28,15 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
 
   public final TimeScale timeScale;
   public final Integer precision;
-  public final Boolean isWithTimezone;
+  public final boolean isWithTimezone;
 
   public SqlPeriodTypeNameSpec(TimeScale timeScale,
       SqlNumericLiteral precision,
-      Boolean isWithTimezone, SqlParserPos pos) {
+      boolean isWithTimezone, SqlParserPos pos) {
     super(new SqlIdentifier("Period",pos), pos);
 
     if (timeScale == TimeScale.DATE
-        && (precision != null || isWithTimezone != null)) {
+        && (precision != null || isWithTimezone == true)) {
       throw SqlUtil.newContextException(pos,
           RESOURCE.illegalNonQueryExpression());
     }
@@ -77,7 +77,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
       writer.endList(frame);
     }
 
-    if (isWithTimezone != null) {
+    if (isWithTimezone == true) {
       writer.keyword("WITH TIME ZONE");
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -26,7 +26,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
 /**
  * A sql type name specification of the PERIOD type.
  */
-public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
+public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
 
   public final TimeScale timeScale;
   public final Integer precision;
@@ -35,7 +35,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
   public SqlPeriodTypeNameSpec(TimeScale timeScale,
       SqlNumericLiteral precision,
       boolean isWithTimezone, SqlParserPos pos) {
-    super(new SqlIdentifier("Period",pos), pos);
+    super(new SqlIdentifier("Period", pos), pos);
 
     // date period cannot contain precision or with time zone token
     if (timeScale == TimeScale.DATE

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -23,6 +23,9 @@ import org.apache.calcite.util.Litmus;
 
 import static org.apache.calcite.util.Static.RESOURCE;
 
+/**
+ * A sql type name specification of the PERIOD type.
+ */
 public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
 
   public final TimeScale timeScale;
@@ -34,8 +37,9 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
       boolean isWithTimezone, SqlParserPos pos) {
     super(new SqlIdentifier("Period",pos), pos);
 
+    // date period cannot contain precision or with time zone token
     if (timeScale == TimeScale.DATE
-        && (precision != null || isWithTimezone == true)) {
+        && (precision != null || isWithTimezone)) {
       throw SqlUtil.newContextException(pos,
           RESOURCE.illegalNonQueryExpression());
     }
@@ -45,7 +49,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
         throw SqlUtil.newContextException(pos,
             RESOURCE.illegalNonQueryExpression());
       }
-      Integer precisionValue = Integer.valueOf(precision.toValue());
+      int precisionValue = Integer.parseInt(precision.toValue());
       if (precisionValue < 0 || precisionValue > 6) {
         throw SqlUtil.newContextException(pos,
             RESOURCE.numberLiteralOutOfRange("Precision"));
@@ -54,7 +58,6 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
     } else {
       this.precision = null;
     }
-
     this.timeScale = timeScale;
     this.isWithTimezone = isWithTimezone;
   }
@@ -75,11 +78,9 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
       writer.print(precision);
       writer.endList(frame);
     }
-
-    if (isWithTimezone == true) {
+    if (isWithTimezone) {
       writer.keyword("WITH TIME ZONE");
     }
-
     writer.endList(periodFrame);
   }
 
@@ -90,6 +91,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
 
     SqlPeriodTypeNameSpec that = (SqlPeriodTypeNameSpec) spec;
 
+    // two period types are the same as long as their time scales are the same
     if (this.timeScale != that.timeScale) {
       return litmus.fail("{} != {}", this, spec);
     }
@@ -98,8 +100,19 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
   }
 
   public enum TimeScale {
+    /**
+     * Time scale is DATE.
+     */
     DATE,
+
+    /**
+     * Time scale is TIME.
+     */
     TIME,
+
+    /**
+     * Time scale is TIMESTAMP.
+     */
     TIMESTAMP
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -69,7 +69,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
     writer.keyword("PERIOD");
     final SqlWriter.Frame periodFrame =
         writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
-
+    writer.keyword(timeScale.toString());
     if (precision != null) {
       final SqlWriter.Frame frame =
           writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -30,18 +30,19 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
 
   public final TimeScale timeScale;
   public final Integer precision;
-  public final boolean isWithTimezone;
+  public final boolean containsWithTimeZone;
 
   private static final int PRECISION_UPPERBOUND = 6;
 
   public SqlPeriodTypeNameSpec(TimeScale timeScale,
       SqlNumericLiteral precision,
-      boolean isWithTimezone, SqlParserPos pos) {
+      boolean containsWithTimeZone, SqlParserPos pos) {
     super(new SqlIdentifier("Period", pos), pos);
 
-    // Date period cannot contain precision or with time zone token.
+    // Period of DATE time scale cannot be used with
+    // PRECISION or WITH TIME ZONE token.
     if (timeScale == TimeScale.DATE
-        && (precision != null || isWithTimezone)) {
+        && (precision != null || containsWithTimeZone)) {
       throw SqlUtil.newContextException(pos,
           RESOURCE.illegalNonQueryExpression());
     }
@@ -61,7 +62,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
       this.precision = null;
     }
     this.timeScale = timeScale;
-    this.isWithTimezone = isWithTimezone;
+    this.containsWithTimeZone = containsWithTimeZone;
   }
 
   @Override public RelDataType deriveType(final SqlValidator validator) {
@@ -80,7 +81,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
       writer.print(precision);
       writer.endList(frame);
     }
-    if (isWithTimezone) {
+    if (containsWithTimeZone) {
       writer.keyword("WITH TIME ZONE");
     }
     writer.endList(periodFrame);
@@ -90,20 +91,14 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
     return false; // Since there is no test for this method, it is left blank.
   }
 
+  /**
+   * A enum for time scales in the period type.
+   */
   public enum TimeScale {
-    /**
-     * Time scale is DATE.
-     */
     DATE,
 
-    /**
-     * Time scale is TIME.
-     */
     TIME,
 
-    /**
-     * Time scale is TIMESTAMP.
-     */
     TIMESTAMP
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -42,9 +42,9 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
 
     // Date period cannot contain precision or with time zone token.
     if (timeScale == TimeScale.DATE
-        && precision != null || isWithTimezone) {
-          throw SqlUtil.newContextException(pos,
-              RESOURCE.illegalNonQueryExpression());
+        && (precision != null || isWithTimezone)) {
+      throw SqlUtil.newContextException(pos,
+          RESOURCE.illegalNonQueryExpression());
     }
 
     if (precision != null) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.Litmus;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
+
+  public final TimeScale timeScale;
+  public final Integer precision;
+  public final Boolean isWithTimezone;
+
+  public SqlPeriodTypeNameSpec(TimeScale timeScale,
+      SqlNumericLiteral precision,
+      Boolean isWithTimezone, SqlParserPos pos) {
+    super(new SqlIdentifier("Period",pos), pos);
+
+    if (timeScale == TimeScale.DATE
+        && (precision != null || isWithTimezone != null)) {
+      throw SqlUtil.newContextException(pos,
+          RESOURCE.illegalNonQueryExpression());
+    }
+
+    if (precision != null) {
+      if (!precision.isInteger()) {
+        throw SqlUtil.newContextException(pos,
+            RESOURCE.illegalNonQueryExpression());
+      }
+      Integer precisionValue = Integer.getInteger(precision.toValue());
+      if (precisionValue < 0 || precisionValue > 6) {
+        throw SqlUtil.newContextException(pos,
+            RESOURCE.numberLiteralOutOfRange("Precision"));
+      }
+      this.precision = precisionValue;
+    } else {
+      this.precision = null;
+    }
+
+    this.timeScale = timeScale;
+    this.isWithTimezone = isWithTimezone;
+  }
+
+  @Override public RelDataType deriveType(final SqlValidator validator) {
+    return validator.getValidatedNodeType(getTypeName());
+  }
+
+  @Override public void unparse(final SqlWriter writer, final int leftPrec,
+      final int rightPrec) {
+    writer.keyword("PERIOD");
+    final SqlWriter.Frame periodFrame =
+        writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+
+    if (precision != null) {
+      final SqlWriter.Frame frame =
+          writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+      writer.print(precision);
+      writer.endList(frame);
+    }
+
+    if (isWithTimezone != null) {
+      writer.keyword("WITH TIME ZONE");
+    }
+
+    writer.endList(periodFrame);
+  }
+
+  @Override public boolean equalsDeep(final SqlTypeNameSpec spec, final Litmus litmus) {
+    if (!(spec instanceof SqlPeriodTypeNameSpec)) {
+      return litmus.fail("{} != {}", this, spec);
+    }
+
+    SqlPeriodTypeNameSpec that = (SqlPeriodTypeNameSpec) spec;
+
+    if (this.timeScale != that.timeScale) {
+      return litmus.fail("{} != {}", this, spec);
+    }
+
+    return litmus.succeed();
+  }
+
+  public enum TimeScale {
+    DATE,
+    TIME,
+    TIMESTAMP
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -33,7 +33,6 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
   public final boolean isWithTimezone;
 
   private static final int PRECISION_UPPERBOUND = 6;
-  private static final int PRECISION_DEFAULT = 6;
 
   public SqlPeriodTypeNameSpec(TimeScale timeScale,
       SqlNumericLiteral precision,
@@ -59,11 +58,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
       }
       this.precision = precisionValue;
     } else {
-      if (timeScale == TimeScale.DATE) {
-        this.precision = null;
-      } else {
-        this.precision = PRECISION_DEFAULT;
-      }
+      this.precision = null;
     }
     this.timeScale = timeScale;
     this.isWithTimezone = isWithTimezone;

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -46,7 +46,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec{
         throw SqlUtil.newContextException(pos,
             RESOURCE.illegalNonQueryExpression());
       }
-      Integer precisionValue = Integer.getInteger(precision.toValue());
+      Integer precisionValue = Integer.valueOf(precision.toValue());
       if (precisionValue < 0 || precisionValue > 6) {
         throw SqlUtil.newContextException(pos,
             RESOURCE.numberLiteralOutOfRange("Precision"));

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -72,6 +72,8 @@ data: {
       "org.apache.calcite.sql.SqlIndex",
       "org.apache.calcite.sql.SqlJsonTypeNameSpec",
       "org.apache.calcite.sql.SqlJsonTypeNameSpec.StorageFormat",
+      "org.apache.calcite.sql.SqlPeriodTypeNameSpec",
+      "org.apache.calcite.sql.SqlPeriodTypeNameSpec.TimeScale",
       "org.apache.calcite.sql.SqlPrimaryIndex",
       "org.apache.calcite.sql.SqlRenameTable",
       "org.apache.calcite.sql.SqlRenameTable.RenameOption",
@@ -1024,6 +1026,7 @@ data: {
     # Return type of method implementation should be "SqlTypeNameSpec".
     # Example: SqlParseTimeStampZ().
     dataTypeParserMethods: [
+      "SqlPeriodDataType()"
       "SqlJsonDataType()"
       "ByteDataType()"
       "ByteIntType()"

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -1026,10 +1026,10 @@ data: {
     # Return type of method implementation should be "SqlTypeNameSpec".
     # Example: SqlParseTimeStampZ().
     dataTypeParserMethods: [
-      "SqlPeriodDataType()"
-      "SqlJsonDataType()"
       "ByteDataType()"
       "ByteIntType()"
+      "SqlJsonDataType()"
+      "SqlPeriodDataType()"
       "VarbyteDataType()"
     ]
 

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2015,6 +2015,11 @@ SqlTypeNameSpec SqlPeriodDataType() :
         }
     |
         <TIME>
+        [
+            <LPAREN>
+            precision = UnsignedNumericLiteral()
+            <RPAREN>
+        ]
         {
             timeScale = TimeScale.TIME;
         }

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2014,7 +2014,11 @@ SqlTypeNameSpec SqlPeriodDataType() :
             timeScale = TimeScale.DATE;
         }
     |
-        <TIME>
+        (
+            <TIME> { timeScale = TimeScale.TIME; }
+        |
+            <TIMESTAMP> { timeScale = TimeScale.TIMESTAMP; }
+        )
         [
             <LPAREN>
             precision = UnsignedNumericLiteral()
@@ -2023,22 +2027,6 @@ SqlTypeNameSpec SqlPeriodDataType() :
         [
             <WITH> <TIME> <ZONE> { isWithTimezone = true; }
         ]
-        {
-            timeScale = TimeScale.TIME;
-        }
-    |
-        <TIMESTAMP>
-        [
-            <LPAREN>
-            precision = UnsignedNumericLiteral()
-            <RPAREN>
-        ]
-        [
-            <WITH> <TIME> <ZONE> { isWithTimezone = true; }
-        ]
-        {
-            timeScale = TimeScale.TIMESTAMP;
-        }
     )
     <RPAREN>
     {

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2026,6 +2026,19 @@ SqlTypeNameSpec SqlPeriodDataType() :
         {
             timeScale = TimeScale.TIME;
         }
+    |
+        <TIMESTAMP>
+        [
+            <LPAREN>
+            precision = UnsignedNumericLiteral()
+            <RPAREN>
+        ]
+        [
+            <WITH> <TIME> <ZONE> { isWithTimezone = true; }
+        ]
+        {
+            timeScale = TimeScale.TIMESTAMP;
+        }
     )
     <RPAREN>
     {

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2028,6 +2028,6 @@ SqlTypeNameSpec SqlPeriodDataType() :
     <RPAREN>
     {
         return new SqlPeriodTypeNameSpec(timeScale, precision, isWithTimezone,
-        getPos());
+            getPos());
     }
 }

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1999,3 +1999,24 @@ int VariableBinaryTypePrecision() :
     <RPAREN>
     { return precision; }
 }
+
+SqlTypeNameSpec SqlPeriodDataType() :
+{
+    final TimeScale timeScale;
+    SqlNumericLiteral precision = null;
+    Boolean isWithTimezone = null;
+}
+{
+    <PERIOD> <LPAREN>
+    (
+        <DATE>
+        {
+            timeScale = TimeScale.DATE;
+        }
+    )
+    <RPAREN>
+    {
+        return new SqlPeriodTypeNameSpec(timeScale, precision, isWithTimezone,
+        getPos());
+    }
+}

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2004,7 +2004,7 @@ SqlTypeNameSpec SqlPeriodDataType() :
 {
     final TimeScale timeScale;
     SqlNumericLiteral precision = null;
-    Boolean isWithTimezone = null;
+    boolean isWithTimezone = false;
 }
 {
     <PERIOD> <LPAREN>
@@ -2019,6 +2019,9 @@ SqlTypeNameSpec SqlPeriodDataType() :
             <LPAREN>
             precision = UnsignedNumericLiteral()
             <RPAREN>
+        ]
+        [
+            <WITH> <TIME> <ZONE> { isWithTimezone = true; }
         ]
         {
             timeScale = TimeScale.TIME;

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2013,6 +2013,11 @@ SqlTypeNameSpec SqlPeriodDataType() :
         {
             timeScale = TimeScale.DATE;
         }
+    |
+        <TIME>
+        {
+            timeScale = TimeScale.TIME;
+        }
     )
     <RPAREN>
     {

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -2009,10 +2009,7 @@ SqlTypeNameSpec SqlPeriodDataType() :
 {
     <PERIOD> <LPAREN>
     (
-        <DATE>
-        {
-            timeScale = TimeScale.DATE;
-        }
+        <DATE> { timeScale = TimeScale.DATE; }
     |
         (
             <TIME> { timeScale = TimeScale.TIME; }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2686,4 +2686,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME))";
     sql(sql).ok(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsTimeWithPrecision() {
+    final String sql = "create table foo (a period(time(2)))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME(2)))";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2723,4 +2723,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "(?s).*Encountered \"with\" at .*";
     sql(sql).fails(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsPrecisionOutOfRangeFails() {
+    final String sql = "create table foo (a period(timestamp(7)^)^)";
+    final String expected = "(?s).*Numeric literal.*out of range.*";
+    sql(sql).fails(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2675,69 +2675,69 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).fails(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsDate() {
+  @Test public void testPeriodTypeNameSpecDate() {
     final String sql = "create table foo (a period(date))";
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(DATE))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsTime() {
+  @Test public void testPeriodTypeNameSpecTime() {
     final String sql = "create table foo (a period(time))";
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsTimeWithPrecision() {
+  @Test public void testPeriodTypeNameSpecTimeWithPrecision() {
     final String sql = "create table foo (a period(time(2)))";
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME(2)))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsTimeWithTimezone() {
+  @Test public void testPeriodTypeNameSpecTimeWithTimezone() {
     final String sql = "create table foo (a period(time with time zone))";
     final String expected =
         "CREATE TABLE `FOO` (`A` PERIOD(TIME WITH TIME ZONE))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsTimeWithPrecisionWithTimezone() {
+  @Test public void testPeriodTypeNameSpecTimeWithPrecisionWithTimezone() {
     final String sql = "create table foo (a period(time(2) with time zone))";
     final String expected =
         "CREATE TABLE `FOO` (`A` PERIOD(TIME(2) WITH TIME ZONE))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsTimeStamp() {
+  @Test public void testPeriodTypeNameSpecTimeStamp() {
     final String sql = "create table foo (a period(timestamp))";
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsTimeStampWithPrecision() {
+  @Test public void testPeriodTypeNameSpecTimeStampWithPrecision() {
     final String sql = "create table foo (a period(timestamp(0)))";
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP(0)))";
     sql(sql).ok(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsDateWithPrecisionFails() {
+  @Test public void testPeriodTypeNameSpecDateWithPrecisionFails() {
     final String sql = "create table foo (a period(date^(^0)))";
     final String expected = "(?s).*Encountered \"\\(\" at .*";
     sql(sql).fails(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsDateWithTimezoneFails() {
+  @Test public void testPeriodTypeNameSpecDateWithTimezoneFails() {
     final String sql = "create table foo (a period(date ^with^ time zone))";
     final String expected = "(?s).*Encountered \"with\" at .*";
     sql(sql).fails(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsPrecisionOutOfRangeFails() {
+  @Test public void testPeriodTypeNameSpecPrecisionOutOfRangeFails() {
     final String sql = "create table foo (a period(timestamp(7)^)^)";
     final String expected = "(?s).*Numeric literal.*out of range.*";
     sql(sql).fails(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecsNegativePrecisionFails() {
+  @Test public void testPeriodTypeNameSpecNegativePrecisionFails() {
     final String sql = "create table foo (a period(time^(^-1)))";
     final String expected = "(?s).*Encountered \"\\( -\" at .*";
     sql(sql).fails(expected);

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2729,4 +2729,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "(?s).*Numeric literal.*out of range.*";
     sql(sql).fails(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsNegativePrecisionFails() {
+    final String sql = "create table foo (a period(time^(^-1)))";
+    final String expected = "(?s).*Encountered \"\\( -\" at .*";
+    sql(sql).fails(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2692,4 +2692,11 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME(2)))";
     sql(sql).ok(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsTimeWithPrecisionWithTimezone() {
+    final String sql = "create table foo (a period(time(2) with time zone))";
+    final String expected =
+        "CREATE TABLE `FOO` (`A` PERIOD(TIME(2) WITH TIME ZONE))";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2683,7 +2683,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
 
   @Test public void testPeriodTypeNameSpecsTime() {
     final String sql = "create table foo (a period(time))";
-    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(time))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME))";
     sql(sql).ok(expected);
   }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2711,4 +2711,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP(0)))";
     sql(sql).ok(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsDateWithPrecisionFails() {
+    final String sql = "create table foo (a period(date^(^0)))";
+    final String expected = "(?s).*Encountered \"\\(\" at .*";
+    sql(sql).fails(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2717,4 +2717,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "(?s).*Encountered \"\\(\" at .*";
     sql(sql).fails(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsDateWithTimezoneFails() {
+    final String sql = "create table foo (a period(date ^with^ time zone))";
+    final String expected = "(?s).*Encountered \"with\" at .*";
+    sql(sql).fails(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2674,4 +2674,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "(?s).*Encountered \"\\( -\" at .*";
     sql(sql).fails(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecs() {
+    final String sql = "create table foo (a period(date))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(DATE))";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2705,4 +2705,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP))";
     sql(sql).ok(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsTimeStampWithPrecision() {
+    final String sql = "create table foo (a period(timestamp(0)))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP(0)))";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2695,7 +2695,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
 
   @Test public void testPeriodTypeNameSpecTime() {
     final String sql = "create table foo (a period(time))";
-    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME(6)))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME))";
     sql(sql).ok(expected);
   }
 
@@ -2708,7 +2708,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
   @Test public void testPeriodTypeNameSpecTimeWithTimezone() {
     final String sql = "create table foo (a period(time with time zone))";
     final String expected =
-        "CREATE TABLE `FOO` (`A` PERIOD(TIME(6) WITH TIME ZONE))";
+        "CREATE TABLE `FOO` (`A` PERIOD(TIME WITH TIME ZONE))";
     sql(sql).ok(expected);
   }
 
@@ -2721,7 +2721,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
 
   @Test public void testPeriodTypeNameSpecTimeStamp() {
     final String sql = "create table foo (a period(timestamp))";
-    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP(6)))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP))";
     sql(sql).ok(expected);
   }
 

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2699,4 +2699,10 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
         "CREATE TABLE `FOO` (`A` PERIOD(TIME(2) WITH TIME ZONE))";
     sql(sql).ok(expected);
   }
+
+  @Test public void testPeriodTypeNameSpecsTimeStamp() {
+    final String sql = "create table foo (a period(timestamp))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP))";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2675,9 +2675,15 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).fails(expected);
   }
 
-  @Test public void testPeriodTypeNameSpecs() {
+  @Test public void testPeriodTypeNameSpecsDate() {
     final String sql = "create table foo (a period(date))";
     final String expected = "CREATE TABLE `FOO` (`A` PERIOD(DATE))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testPeriodTypeNameSpecsTime() {
+    final String sql = "create table foo (a period(time))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(time))";
     sql(sql).ok(expected);
   }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2693,6 +2693,13 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testPeriodTypeNameSpecsTimeWithTimezone() {
+    final String sql = "create table foo (a period(time with time zone))";
+    final String expected =
+        "CREATE TABLE `FOO` (`A` PERIOD(TIME WITH TIME ZONE))";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testPeriodTypeNameSpecsTimeWithPrecisionWithTimezone() {
     final String sql = "create table foo (a period(time(2) with time zone))";
     final String expected =

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -2695,7 +2695,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
 
   @Test public void testPeriodTypeNameSpecTime() {
     final String sql = "create table foo (a period(time))";
-    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIME(6)))";
     sql(sql).ok(expected);
   }
 
@@ -2708,7 +2708,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
   @Test public void testPeriodTypeNameSpecTimeWithTimezone() {
     final String sql = "create table foo (a period(time with time zone))";
     final String expected =
-        "CREATE TABLE `FOO` (`A` PERIOD(TIME WITH TIME ZONE))";
+        "CREATE TABLE `FOO` (`A` PERIOD(TIME(6) WITH TIME ZONE))";
     sql(sql).ok(expected);
   }
 
@@ -2721,7 +2721,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
 
   @Test public void testPeriodTypeNameSpecTimeStamp() {
     final String sql = "create table foo (a period(timestamp))";
-    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP))";
+    final String expected = "CREATE TABLE `FOO` (`A` PERIOD(TIMESTAMP(6)))";
     sql(sql).ok(expected);
   }
 


### PR DESCRIPTION
By adding a SqlNameSpec type class, now user can define type to be a period type.