### PR TITLE
[CALCITE] Rework of CREATE TABLE COMPRESS attribute

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlColumnAttributeCompress.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlColumnAttributeCompress.java
@@ -23,30 +23,36 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  */
 public class SqlColumnAttributeCompress extends SqlColumnAttribute {
 
-  private final SqlNodeList values;
+  private final SqlNode value;
 
   /**
    * Creates a {@code SqlColumnAttributeCompress}.
    *
    * @param pos  Parser position, must not be null
-   * @param values  Values to be compressed in a particular column. These can be string literals,
-   *                numeric literals or DATEs.
+   * @param value  Value(s) to be compressed in a particular column. These can
+   *               be an individual string or numeric literal or a list
+   *               of string literals, numeric literals, nulls, and DATEs.
    */
-  public SqlColumnAttributeCompress(SqlParserPos pos, SqlNodeList values) {
+  public SqlColumnAttributeCompress(SqlParserPos pos, SqlNode value) {
     super(pos);
-    this.values = values;
+    this.value = value;
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword("COMPRESS");
-    if (values == null) {
+    if (value == null) {
       return;
     }
-    SqlWriter.Frame frame = writer.startList("(", ")");
-    for (SqlNode value : values) {
-      writer.sep(",", false);
-      value.unparse(writer, 0, 0);
+    if (value instanceof SqlNodeList) {
+      SqlNodeList values = (SqlNodeList) value;
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode v : values) {
+        writer.sep(",", false);
+        v.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    } else {
+      value.unparse(writer, leftPrec, rightPrec);
     }
-    writer.endList(frame);
   }
 }

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -384,13 +384,58 @@ SqlColumnAttribute ColumnAttributeUpperCase() :
 
 SqlColumnAttribute ColumnAttributeCompress() :
 {
-    SqlNodeList values = null;
+    SqlNode value = null;
 }
 {
     <COMPRESS>
-    [ values = ParenthesizedQueryOrCommaList(ExprContext.ACCEPT_NONCURSOR) ]
+    [
+        value = StringLiteral()
+    |
+        value = NumericLiteral()
+    |
+        value = ParenthesizedCompressCommaList()
+    ]
     {
-        return new SqlColumnAttributeCompress(getPos(), values);
+        return new SqlColumnAttributeCompress(getPos(), value);
+    }
+}
+
+SqlNodeList ParenthesizedCompressCommaList() :
+{
+    final List<SqlNode> values = new ArrayList<SqlNode>();
+    SqlNode value = null;
+}
+{
+    <LPAREN>
+    value = CompressOption() { values.add(value); }
+    (
+        <COMMA>
+        value = CompressOption() { values.add(value); }
+    )*
+    <RPAREN>
+    {
+        return new SqlNodeList(values, getPos());
+    }
+}
+
+SqlNode CompressOption() :
+{
+    SqlNode value;
+}
+{
+    (
+        value = StringLiteral()
+    |
+        value = NumericLiteral()
+    |
+        value = DateTimeLiteral()
+    |
+        <NULL> {
+            value = SqlLiteral.createNull(getPos());
+        }
+    )
+    {
+        return value;
     }
 }
 

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -761,6 +761,32 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testCreateTableCompressWithStringLiteralColumnLevelAttribute() {
+    final String sql = "create table foo (bar char(3) compress 'xyz')";
+    final String expected = "CREATE TABLE `FOO` (`BAR` CHAR(3) COMPRESS 'xyz')";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateTableCompressWithNumericLiteralColumnLevelAttribute() {
+    final String sql = "create table foo (bar integer compress 3)";
+    final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER COMPRESS 3)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateTableCompressWithNullColumnLevelAttribute() {
+    final String sql = "create table foo (bar integer compress (NULL))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER COMPRESS (NULL))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateTableCompressWithMixedTypesColumnLevelAttribute() {
+    final String sql = "create table foo (bar integer compress (1, 'x', "
+        + "DATE '1972-02-28'))";
+    final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER COMPRESS (1, 'x',"
+        + " DATE '1972-02-28'))";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testCreateTableNullColumnLevelAttribute() {
     final String sql = "create table foo (bar int null)";
     final String expected = "CREATE TABLE `FOO` (`BAR` INTEGER)";


### PR DESCRIPTION
- COMPRESS can now be specified on a constant without parentheses but still supports a list
- Refactored SqlColumnAttributeCompress to allow for a single value or a list of values
- Added new tests