### PR TITLE
[CALCITE] Update SqlClobTypeNameSpec's isValidMaxLength() switch/case

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlClobTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlClobTypeNameSpec.java
@@ -84,6 +84,8 @@ public class SqlClobTypeNameSpec extends SqlTypeNameSpec {
         return false;
       }
       break;
+    default:
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
Otherwise, we receive linter errors that this is not an exhaustive switch/case across all CharacterSet enum values.