### PR TITLE
[CALCITE] Small fixes to formatting, field visibility, and using sep() during unparsing

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlBlobTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBlobTypeNameSpec.java
@@ -86,14 +86,14 @@ public class SqlBlobTypeNameSpec extends SqlTypeNameSpec {
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword("BLOB");
     if (maxLength != null) {
-      writer.setNeedWhitespace(false);
-      writer.sep("(");
+      final SqlWriter.Frame frame =
+          writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
       maxLength.unparse(writer, 0, 0);
       if (unitSize != SqlLobUnitSize.UNSPECIFIED) {
         writer.setNeedWhitespace(false);
         writer.print(unitSize.toString());
       }
-      writer.sep(")");
+      writer.endList(frame);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlClobTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlClobTypeNameSpec.java
@@ -97,17 +97,17 @@ public class SqlClobTypeNameSpec extends SqlTypeNameSpec {
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword("CLOB");
     if (maxLength != null) {
-      writer.setNeedWhitespace(false);
-      writer.sep("(");
+      final SqlWriter.Frame frame =
+          writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
       maxLength.unparse(writer, 0, 0);
       if (unitSize != SqlLobUnitSize.UNSPECIFIED) {
         writer.setNeedWhitespace(false);
         writer.print(unitSize.toString());
       }
-      writer.sep(")");
+      writer.endList(frame);
     }
     if (characterSet != null) {
-      writer.keyword("CHARACTER SET " + characterSet.toString());
+      writer.keyword("CHARACTER SET " + characterSet);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlColumnAttributeCompress.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlColumnAttributeCompress.java
@@ -23,7 +23,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  */
 public class SqlColumnAttributeCompress extends SqlColumnAttribute {
 
-  private final SqlNode value;
+  public final SqlNode value;
 
   /**
    * Creates a {@code SqlColumnAttributeCompress}.

--- a/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlPeriodTypeNameSpec.java
@@ -96,9 +96,7 @@ public class SqlPeriodTypeNameSpec extends SqlTypeNameSpec {
    */
   public enum TimeScale {
     DATE,
-
     TIME,
-
-    TIMESTAMP
+    TIMESTAMP,
   }
 }


### PR DESCRIPTION
- removed occurrences of sep() calls during unparsing that were not within an outer frame
- removed call to toString() on an enum where not required
- modified SqlColumnAttributeCompress's value field to be public
- changed formatting in TimeScale enum