### PR TITLE
[CALCITE] Update inline MOD operator to handle compound identifiers

### DIFF
--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1306,7 +1306,7 @@ SqlNode InlineModOperator() :
     (
         e = NumericLiteral()
     |
-        e = SimpleIdentifier()
+        e = CompoundIdentifier()
     )
     {
         s = span();
@@ -1318,7 +1318,7 @@ SqlNode InlineModOperator() :
     (
         e = NumericLiteral()
     |
-        e = SimpleIdentifier()
+        e = CompoundIdentifier()
     )
     {
         args.add(e);

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -1528,9 +1528,15 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
-  @Test public void testInlineModSyntaxIdentifier() {
+  @Test public void testInlineModSyntaxSimpleIdentifiers() {
     final String sql = "select foo mod bar";
     final String expected = "SELECT MOD(`FOO`, `BAR`)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testInlineModSyntaxCompoundIdentifiers() {
+    final String sql = "select foo.bar mod baz.qux";
+    final String expected = "SELECT MOD(`FOO`.`BAR`, `BAZ`.`QUX`)";
     sql(sql).ok(expected);
   }
 


### PR DESCRIPTION
[CALCITE] Update inline MOD operator to handle compound identifiers
