### PR TITLE
[CALCITE] Added support for CREATE/REPLACE MACRO statements

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
@@ -67,8 +67,9 @@ public class SqlCreateMacro extends SqlCreate implements SqlExecutableStatement 
     final SqlWriter.Frame frame =
         writer.startList(SqlWriter.FrameTypeEnum.CREATE_MACRO, "(", ")");
     for (SqlNode s : sqlStatements) {
-      writer.sep(";", false);
       s.unparse(writer, 0, 0);
+      writer.setNeedWhitespace(false);
+      writer.sep(";");
     }
     writer.endList(frame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.Objects;
+import java.util.List;
+
+/**
+ * Parse tree for {@code CREATE MACRO} statement.
+ */
+public class SqlCreateMacro extends SqlCreate implements SqlExecutableStatement {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("CREATE MACRO", SqlKind.CREATE_MACRO);
+
+  private final SqlNodeList attributes;
+  private final SqlNodeList sqlStatements;
+
+  /** Creates a {@code SqlCreateMacro}. */
+  public SqlCreateMacro(SqlParserPos pos, SqlCreateSpecifier createSpecifier,
+      boolean ifNotExists, SqlNodeList attributes, SqlNodeList sqlStatements) {
+    super(OPERATOR, pos, createSpecifier, ifNotExists);
+    this.attributes = attributes; // May be null.
+    this.sqlStatements = Objects.requireNonNull(sqlStatements);
+  }
+
+  @Override public List<SqlNode> getOperandList() {
+    return ImmutableNullableList.of(attributes, sqlStatements);
+  }
+
+  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword(getCreateSpecifier().toString());
+    writer.keyword("MACRO");
+    if (attributes != null) {
+      SqlWriter.Frame frame = writer.startList("(", ")");
+      for (SqlNode a : attributes) {
+        writer.sep(",");
+        a.unparse(writer, 0, 0);
+      }
+      writer.endList(frame);
+    }
+    writer.keyword("AS");
+    SqlWriter.Frame frame = writer.startList("(", ")");
+    for (SqlNode s : sqlStatements) {
+      writer.sep(";");
+      s.unparse(writer, 0, 0);
+    }
+    writer.endList(frame);
+  }
+
+  // Intentionally left empty.
+  @Override public void execute(CalcitePrepare.Context context) {}
+}

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
@@ -30,9 +30,9 @@ public class SqlCreateMacro extends SqlCreate implements SqlExecutableStatement 
   private static final SqlSpecialOperator OPERATOR =
       new SqlSpecialOperator("CREATE MACRO", SqlKind.CREATE_MACRO);
 
-  private final SqlIdentifier macroName;
-  private final SqlNodeList attributes;
-  private final SqlNodeList sqlStatements;
+  public final SqlIdentifier macroName;
+  public final SqlNodeList attributes;
+  public final SqlNodeList sqlStatements;
 
   /** Creates a {@code SqlCreateMacro}. */
   public SqlCreateMacro(SqlParserPos pos, SqlCreateSpecifier createSpecifier,

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateMacro.java
@@ -20,8 +20,8 @@ import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
-import java.util.Objects;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Parse tree for {@code CREATE MACRO} statement.

--- a/core/src/main/java/org/apache/calcite/sql/SqlInsert.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlInsert.java
@@ -132,7 +132,7 @@ public class SqlInsert extends SqlCall {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    writer.startList(SqlWriter.FrameTypeEnum.SELECT);
+    SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.SELECT);
     writer.sep(isUpsert() ? "UPSERT INTO" : "INSERT INTO");
     final int opLeft = getOperator().getLeftPrec();
     final int opRight = getOperator().getRightPrec();
@@ -142,6 +142,7 @@ public class SqlInsert extends SqlCall {
     }
     writer.newlineAndIndent();
     source.unparse(writer, 0, 0);
+    writer.endList(frame);
   }
 
   public void validate(SqlValidator validator, SqlValidatorScope scope) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1098,6 +1098,9 @@ public enum SqlKind {
   /** {@code DROP SCHEMA} DDL statement. */
   DROP_SCHEMA,
 
+  /** {@code CREATE MACRO} DDL statement. */
+  CREATE_MACRO,
+
   /** {@code CREATE TABLE} DDL statement. */
   CREATE_TABLE,
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlWriter.java
@@ -243,6 +243,11 @@ public interface SqlWriter {
     CASE,
 
     /**
+     * CREATE_MACRO expression.
+     */
+    CREATE_MACRO,
+
+    /**
      * Same behavior as user-defined frame type.
      */
     OTHER;

--- a/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
+++ b/core/src/main/java/org/apache/calcite/sql/pretty/SqlPrettyWriter.java
@@ -390,7 +390,8 @@ public class SqlPrettyWriter implements SqlWriter {
     return (frame == null)
         || (frame.frameType == FrameTypeEnum.ORDER_BY)
         || (frame.frameType == FrameTypeEnum.WITH)
-        || (frame.frameType == FrameTypeEnum.SETOP);
+        || (frame.frameType == FrameTypeEnum.SETOP)
+        || (frame.frameType == FrameTypeEnum.CREATE_MACRO);
   }
 
   @Deprecated

--- a/parsing/dialects/dialect1/config.fmpp
+++ b/parsing/dialects/dialect1/config.fmpp
@@ -61,6 +61,7 @@ data: {
       "org.apache.calcite.sql.SqlCreateFunctionSqlForm",
       "org.apache.calcite.sql.SqlCreateFunctionSqlForm.DeterministicType",
       "org.apache.calcite.sql.SqlCreateFunctionSqlForm.ReactToNullInputType",
+      "org.apache.calcite.sql.SqlCreateMacro",
       "org.apache.calcite.sql.SqlCreateTableDialect1",
       "org.apache.calcite.sql.SqlDateTimeAtLocal",
       "org.apache.calcite.sql.SqlDateTimeAtTimeZone",
@@ -1069,6 +1070,7 @@ data: {
     # "(CREATE [OR REPLACE] | REPLACE)" calls.
     createStatementParserMethods: [
       "SqlCreateForeignSchema"
+      "SqlCreateMacro"
       "SqlCreateMaterializedView"
       "SqlCreateSchema"
       "SqlCreateTable"

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -981,40 +981,12 @@ SqlCreate SqlCreateMacro() :
         { attributes = null; }
     )
     <AS>
-    sqlStatements = ParenthesizedSqlStmtList()
+    <LPAREN>
+    sqlStatements = SqlStmtList()
+    <RPAREN>
     {
         return new SqlCreateMacro(s.end(this), createSpecifier, macroName,
             attributes, sqlStatements);
-    }
-}
-
-/**
- * Parses a list of SQL statements enclosed in parentheses and
- * separated by semicolon. The semicolon is required between statements, but is
- * optional at the end. Can't use existing SqlStmtList() as that function
- * expects <EOF> at the end.
- */
-SqlNodeList ParenthesizedSqlStmtList() :
-{
-    final List<SqlNode> stmtList = new ArrayList<SqlNode>();
-    SqlNode stmt;
-}
-{
-    <LPAREN>
-    stmt = SqlStmt() {
-        stmtList.add(stmt);
-    }
-    (
-        <SEMICOLON>
-        [
-            stmt = SqlStmt() {
-                stmtList.add(stmt);
-            }
-        ]
-    )*
-    <RPAREN>
-    {
-        return new SqlNodeList(stmtList, Span.of(stmtList).pos());
     }
 }
 

--- a/parsing/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/dialect1/parserImpls.ftl
@@ -1017,6 +1017,7 @@ SqlNodeList ParenthesizedSqlStmtList() :
         return new SqlNodeList(stmtList, Span.of(stmtList).pos());
     }
 }
+
 SqlCreate SqlCreateFunctionSqlForm() :
 {
     final Span s;

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3215,4 +3215,33 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     final String expected = "DROP MACRO `FOO`";
     sql(sql).ok(expected);
   }
+
+  @Test public void testCreateMacroNoAttributes() {
+    final String sql = "create macro foo as (select * from bar;)";
+    final String expected = "CREATE MACRO `FOO` AS (SELECT *\n"
+        + "FROM `BAR`;)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateMacroInsertStatement() {
+    final String sql = "create macro foo (num int) as (insert into bar (num)"
+        + " values (:num);)";
+    final String expected = "CREATE MACRO `FOO` (`NUM` INTEGER) AS "
+        + "(INSERT INTO `BAR` (`NUM`)\n"
+        + "VALUES (ROW(:NUM));)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCreateMacroInsertAndSelectStatements() {
+    final String sql = "create macro foo (dob date format 'mmddyy') as "
+        + "(insert into bar (dob) values(:dob);"
+        + " select * from bar where dob = :dob; )";
+    final String expected = "CREATE MACRO `FOO` (`DOB` DATE FORMAT 'mmddyy') AS"
+        + " (INSERT INTO `BAR` (`DOB`)\n"
+        + "VALUES (ROW(:DOB)); SELECT *\n"
+        + "FROM `BAR`\n"
+        + "WHERE (`DOB` = :DOB);)";
+
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3241,7 +3241,18 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
         + "VALUES (ROW(:DOB)); SELECT *\n"
         + "FROM `BAR`\n"
         + "WHERE (`DOB` = :DOB);)";
+    sql(sql).ok(expected);
+  }
 
+  @Test public void testCreateMacroUpdateAndSelectStatements() {
+    final String sql = "create macro foo (num int default 99, val varchar"
+        + " not null) as (update bar set num = :num where val = :val;"
+        + " select * from bar where num = :num)";
+    final String expected = "CREATE MACRO `FOO` (`NUM` INTEGER DEFAULT 99, `VAL`"
+        + " VARCHAR NOT NULL) AS (UPDATE `BAR` SET `NUM` = :NUM\n"
+        + "WHERE (`VAL` = :VAL); SELECT *\n"
+        + "FROM `BAR`\n"
+        + "WHERE (`NUM` = :NUM);)";
     sql(sql).ok(expected);
   }
 }

--- a/parsing/src/main/resources/Parser.jj
+++ b/parsing/src/main/resources/Parser.jj
@@ -230,7 +230,7 @@ public class ${parser.class} extends SqlAbstractParserImpl
     }
 
     public SqlNodeList parseSqlStmtList() throws Exception {
-        return SqlStmtList();
+        return SqlStmtListEof();
     }
 
     private SqlNode extend(SqlNode table, SqlNodeList extendList) {
@@ -978,6 +978,23 @@ SqlNode SqlQueryEof() :
 }
 
 /**
+ * Parses a list of SQL statements separated by semicolon with an <EOF> expected.
+ * The semicolon is required between statements, but is
+ * optional at the end.
+ */
+SqlNodeList SqlStmtListEof() :
+{
+    final SqlNodeList stmtList;
+}
+{
+    stmtList = SqlStmtList()
+    <EOF>
+    {
+        return stmtList;
+    }
+}
+
+/**
  * Parses a list of SQL statements separated by semicolon.
  * The semicolon is required between statements, but is
  * optional at the end.
@@ -999,7 +1016,6 @@ SqlNodeList SqlStmtList() :
             }
         ]
     )*
-    <EOF>
     {
         return new SqlNodeList(stmtList, Span.of(stmtList).pos());
     }


### PR DESCRIPTION
- Added new CREATE_MACRO frame type to ensure that SELECT statements in the body aren't unparsed with parens
- Added new AST node SqlCreateMacro and corresponding parsing logic
- Fixed bug where SELECT list created in SqlInsert was never closed