### PR TITLE
[CALCITE] DialectGenerate can now parse function with types that contain periods

### DIFF
--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/DialectGenerate.java
@@ -33,7 +33,7 @@ public class DialectGenerate {
 
   // Matches foo<body> where body can be [\w\s<>,]. This allows for easy
   // handling of nested angle brackets and comma separated values.
-  private static final String TYPE = "\\w+\\s*(<\\s*[\\w<>,\\s]+>)?";
+  private static final String TYPE = "[\\w\\.]+\\s*(<\\s*[\\w<>,\\s]+>)?";
   private static final String TYPE_AND_NAME = TYPE + "\\s+\\w+";
   private static final String SPLIT_DELIMS = "(\\s|\n|\"|//|/\\*|\\*/|'|\\}|\\{)";
 

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/DialectGenerateTest.java
@@ -245,4 +245,9 @@ public class DialectGenerateTest {
     String declaration = "Map<String, String> foo(String x, int y) :";
     assertFunctionNameExtracted(declaration, "foo");
   }
+
+  @Test public void getFunctionNameWithDot() {
+    String declaration = "Foo.Bar baz() :";
+    assertFunctionNameExtracted(declaration, "baz");
+  }
 }

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated.txt
@@ -36,3 +36,10 @@ void bar( int a, int b ) :
     */
 }
 
+Foo.Bar baz () :
+{
+
+}
+{
+
+}

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated_expected.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated_expected.txt
@@ -32,3 +32,10 @@ void bar( int a, int b ) :
         // }
     */
 }
+Foo.Bar baz () :
+{
+
+}
+{
+
+}


### PR DESCRIPTION
Required to handle this [use case](https://github.com/googleinterns/calcite/blob/916228a2fda68521c16e564f4deaaa42b147fba8/parsing/src/main/resources/Parser.jj#L1430).