### PR TITLE
[CALCITE] Fixed bug where CurlyParser would not parse escaped backslashes in a string

### DIFF
--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/CurlyParser.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/CurlyParser.java
@@ -136,9 +136,9 @@ public class CurlyParser {
 
   /**
    * Determines if the current token is escaped based on how many consecutive
-   * backslashes preceeded it. An even number of backslashes implies the token
+   * backslashes precede it. An even number of backslashes implies the token
    * is not escaped (as in that case the backslash itself is escaped), while
-   * and odd number implies that the token is escaped.
+   * an odd number implies that the token is escaped.
    */
   private boolean isEscaped() {
     return consecutiveBackslashes % 2 == 1;

--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/CurlyParser.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/CurlyParser.java
@@ -64,7 +64,9 @@ public class CurlyParser {
   // legally encountered (those that are not within any structure).
   private int curlyCounter = 0;
 
-  private String previousToken = "";
+  // Keeps track of the number of consecutive backslashes so it can be
+  // determined if the current token is escaped or not.
+  private int consecutiveBackslashes = 0;
 
   /**
    * Parses the given token and updates the state. It is assumed that the
@@ -92,13 +94,13 @@ public class CurlyParser {
       if (insideState == InsideState.SINGLE_COMMENT) {
         insideState = InsideState.NONE;
       }
-    } else if (token.equals("\"") && !previousToken.equals("\\")) {
+    } else if (token.equals("\"") && !isEscaped()) {
       if (insideState == InsideState.NONE) {
         insideState = InsideState.STRING;
       } else if (insideState == InsideState.STRING) {
         insideState = InsideState.NONE;
       }
-    } else if (token.equals("'") && !previousToken.equals("\\")) {
+    } else if (token.equals("'") && !isEscaped()) {
       if (insideState == InsideState.NONE) {
         insideState = InsideState.CHARACTER;
       } else if (insideState == InsideState.CHARACTER) {
@@ -125,6 +127,20 @@ public class CurlyParser {
         curlyCounter--;
       }
     }
-    previousToken = token;
+    if (token.equals("\\")) {
+      consecutiveBackslashes++;
+    } else {
+      consecutiveBackslashes = 0;
+    }
+  }
+
+  /**
+   * Determines if the current token is escaped based on how many consecutive
+   * backslashes preceeded it. An even number of backslashes implies the token
+   * is not escaped (as in that case the backslash itself is escaped), while
+   * and odd number implies that the token is escaped.
+   */
+  private boolean isEscaped() {
+    return consecutiveBackslashes % 2 == 1;
   }
 }

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/CurlyParserTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/CurlyParserTest.java
@@ -76,8 +76,13 @@ public class CurlyParserTest {
     assertCurlyParserSucceeds(input);
   }
 
+  @Test public void testCurlyParserParsesEscapedBackslashInSingleQuotes() {
+    String input = "{ '\\\\'  }";
+    assertCurlyParserSucceeds(input);
+  }
+
   @Test public void testCurlyParserParsesEscapedBackslash() {
-    String input = "{ String x = \" \\ \" }";
+    String input = "{ String x = \"\\\\\" }";
     assertCurlyParserSucceeds(input);
   }
 

--- a/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/CurlyParserTest.java
+++ b/buildSrc/subprojects/parser/src/test/java/org/apache/calcite/test/CurlyParserTest.java
@@ -76,6 +76,11 @@ public class CurlyParserTest {
     assertCurlyParserSucceeds(input);
   }
 
+  @Test public void testCurlyParserParsesEscapedBackslash() {
+    String input = "{ String x = \" \\ \" }";
+    assertCurlyParserSucceeds(input);
+  }
+
   @Test public void testCurlyParserParsesNestedValidCurlyBlocks() {
     String input = "{ {  } }";
     assertCurlyParserSucceeds(input);

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated.txt
@@ -19,6 +19,7 @@ void foo(int a) :
 {
     String x = "}";
     String y = "\"";
+    String z = "\\";
 }
 {
     /*

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated.txt
@@ -20,6 +20,7 @@ void foo(int a) :
     String x = "}";
     String y = "\"";
     String z = "\\";
+    char l = '\\';
 }
 {
     /*

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated_expected.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated_expected.txt
@@ -19,6 +19,7 @@ void foo(int a) :
     String x = "}";
     String y = "\"";
     String z = "\\";
+    char l = '\\';
 }
 {
     /*

--- a/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated_expected.txt
+++ b/buildSrc/subprojects/parser/src/test/resources/processFileTests/multiple_functions_separated/multiple_functions_separated_expected.txt
@@ -18,6 +18,7 @@ void foo(int a) :
 {
     String x = "}";
     String y = "\"";
+    String z = "\\";
 }
 {
     /*


### PR DESCRIPTION
A bug was introduced in https://github.com/googleinterns/calcite/pull/198 which prevented escaped backslashes from being parsed within double quotes. 