### PR TITLE
[CALCITE] Fixed redundant negative in integer-to-interval coercion.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/implicit/TypeCoercionImpl.java
@@ -187,8 +187,9 @@ public class TypeCoercionImpl extends AbstractTypeCoercion {
     SqlIntervalQualifier qualifier =
         new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.DAY, numeric.getParserPosition());
     int sign = ((BigDecimal) numeric.getValue()).signum();
+    String absoluteNumeric = ((BigDecimal) numeric.getValue()).abs().toString();
     SqlIntervalLiteral interval =
-        SqlLiteral.createInterval(sign, numeric.toValue(), qualifier, numeric.getParserPosition());
+        SqlLiteral.createInterval(sign, absoluteNumeric, qualifier, numeric.getParserPosition());
     call.setOperand(numericIndex, interval);
     updateInferredType(numeric, factory.createSqlIntervalType(qualifier));
     return true;

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11569,4 +11569,13 @@ class SqlValidatorTest extends SqlValidatorTestCase {
         + "`B`.`DEPTNO`, TIMESTAMP '1970-01-01 00:00:00', 1, 2, 3, FALSE))";
     sql(sql).withConformance(SqlConformanceEnum.BIG_QUERY).rewritesTo(expected);
   }
+
+  @Test public void testCoerceInterval() {
+    String sql = "select -2 + CURRENT_DATE()";
+    String expected = "SELECT INTERVAL -'2' DAY + CURRENT_DATE";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .withConformance(SqlConformanceEnum.LENIENT)
+        .rewritesTo(expected);
+  }
 }


### PR DESCRIPTION
Fixed bug which rewrites 
SELECT -2 + CURRENT_DATE()
to 
SELECT INTERVAL -'-2' DAY + CURRENT_DATE
(with a double negative sign).

The query should now be rewritten to
SELECT INTERVAL -'2' DAY + CURRENT_DATE
With only a single negative sign outside of the quoted string.