### PR TITLE
[CALCITE] Added support for expressions in inline MOD operator

### DIFF
--- a/parsing/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -1540,6 +1540,14 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testInlineModSyntaxExpressions() {
+    final String sql = "select (select foo from bar) mod (select baz from qux)";
+    final String expected = "SELECT MOD((SELECT `FOO`\n"
+        + "FROM `BAR`), (SELECT `BAZ`\n"
+        + "FROM `QUX`))";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testDateAtLocalWhere() {
     final String sql = "SELECT * FROM foo WHERE bar = DATE AT LOCAL";
     final String expected = "SELECT *\n"


### PR DESCRIPTION
Added support for expressions in inline MOD operator using a setup similar to [AlternativeTypeConversionQuery()](https://github.com/googleinterns/calcite/blob/master/parsing/intermediate/dialects/dialect1/parserImpls.ftl#L4055).