### PR TITLE
[CALCITE] Update Keyword custom equals logic

### DIFF
--- a/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/Keyword.java
+++ b/buildSrc/subprojects/parser/src/main/java/org/apache/calcite/buildtools/parser/Keyword.java
@@ -47,11 +47,7 @@ public class Keyword {
   }
 
   @Override public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    } else if (obj == null) {
-      return false;
-    } else if (!(obj instanceof Keyword)) {
+    if (!(obj instanceof Keyword)) {
       return false;
     }
     Keyword other = (Keyword) obj;


### PR DESCRIPTION
The instanceof operator should automatically handle the null check. Also, the keyword.equals() below should cover the (this == obj) equality check.