### PR TITLE
[CALCITE] Make Calcite unit tests compatible with Google's Java version

### DIFF
--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -1958,7 +1958,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkType("{fn CURTIME()}", "TIME(0) NOT NULL");
     tester.checkScalar("{fn DAYNAME(DATE '2014-12-10')}",
         // Day names in root locale changed from long to short in JDK 9
-        TestUtil.getJavaMajorVersion() <= 8 ? "Wednesday" : "Wed",
+        TestUtil.isShortDayFormat() ? "Wed" : "Wednesday",
         "VARCHAR(2000) NOT NULL");
     tester.checkScalar("{fn DAYOFMONTH(DATE '2014-12-10')}", 10,
         "BIGINT NOT NULL");
@@ -1977,7 +1977,7 @@ public abstract class SqlOperatorBaseTest {
     tester.checkScalar("{fn MONTH(DATE '2014-12-10')}", 12, "BIGINT NOT NULL");
     tester.checkScalar("{fn MONTHNAME(DATE '2014-12-10')}",
         // Month names in root locale changed from long to short in JDK 9
-        TestUtil.getJavaMajorVersion() <= 8 ? "December" : "Dec",
+        TestUtil.isShortDayFormat() ? "Dec" : "December",
         "VARCHAR(2000) NOT NULL");
     tester.checkType("{fn NOW()}", "TIMESTAMP(0) NOT NULL");
     tester.checkScalar("{fn QUARTER(DATE '2014-12-10')}", "4",

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -8005,7 +8005,7 @@ public class JdbcTest {
       // In root locale, for Java versions 9 and higher, day and month names
       // are shortened to 3 letters. This means root locale behaves differently
       // to English.
-      return TestUtil.getJavaMajorVersion() > 8 ? name.substring(0, 3) : name;
+      return TestUtil.isShortDayFormat() ? name.substring(0, 3) : name;
     }
 
     public final String localeName;

--- a/core/src/test/java/org/apache/calcite/util/TestUtil.java
+++ b/core/src/test/java/org/apache/calcite/util/TestUtil.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Assertions;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,6 +46,11 @@ public abstract class TestUtil {
 
   private static final String JAVA_VERSION =
       System.getProperties().getProperty("java.version");
+
+  // True when day names are printed as abbreviations by default (ex. "Thu"
+  // than "Thursday"). Different Java versions print dates differently.
+  private static final boolean IS_SHORT_DAY_FORMAT = LocalDate.of(1970, 1, 1)
+      .format(DateTimeFormatter.ofPattern("EEEE", Locale.ROOT)).length() == 3;
 
   /** This is to be used by {@link #rethrow(Throwable, String)} to add extra information via
    * {@link Throwable#addSuppressed(Throwable)}. */
@@ -224,6 +232,13 @@ public abstract class TestUtil {
     }
 
     return Integer.parseInt(matcher.group());
+  }
+
+  /** Returns true if current Java version prints days in abbreviated format
+   * (ex. "Thu" rather than "Thursday").
+   */
+  public static boolean isShortDayFormat() {
+    return IS_SHORT_DAY_FORMAT;
   }
 
   /** Checks if exceptions have give substring. That is handy to prevent logging SQL text twice */

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -61,9 +61,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -612,7 +610,6 @@ public class Linq4jTest {
   @Test void testIdentityEqualityComparer() {
     final Integer one = 1000;
     final Integer one2 = Integer.valueOf(one.toString());
-    assertThat(one, not(sameInstance(one2)));
     final Integer two = 2;
     final EqualityComparer<Integer> idComparer = Functions.identityComparer();
     assertTrue(idComparer.equal(one, one));


### PR DESCRIPTION
Fixes unit tests that are currently failing on Cloudtop environment due to faulty assumptions.