### PR TITLE
[CALCITE] Extended caret negation and NOT support before operators

### DIFF
--- a/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
@@ -3008,6 +3008,109 @@ SqlPrefixOperator PrefixRowOperator() :
 }
 
 /**
+ * Parses a binary row operator like AND.
+ */
+SqlBinaryOperator BinaryRowOperator() :
+{
+    SqlBinaryOperator op;
+}
+{
+    // <IN> is handled as a special case
+    (
+        <EQ> { return SqlStdOperatorTable.EQUALS; }
+    |
+        ( <GT> | (<CARET> | <NOT>) <LE> ) {
+            return SqlStdOperatorTable.GREATER_THAN;
+        }
+    |
+        ( <LT> | (<CARET> | <NOT>) <GE> ) {
+            return SqlStdOperatorTable.LESS_THAN;
+        }
+    |
+        ( <LE> | (<CARET> | <NOT>) <GT> ) {
+            return SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
+        }
+    |
+        ( <GE> | (<CARET> | <NOT>) <LT> ) {
+            return SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
+        }
+    |
+        ( <NE> | (<CARET> | <NOT>) <EQ> )
+        {
+            return SqlStdOperatorTable.NOT_EQUALS;
+        }
+    |
+        <NE2> {
+            if (!this.conformance.isBangEqualAllowed()) {
+                throw SqlUtil.newContextException(getPos(),
+                    RESOURCE.bangEqualNotAllowed());
+            }
+            return SqlStdOperatorTable.NOT_EQUALS;
+        }
+    |
+        <PLUS> { return SqlStdOperatorTable.PLUS; }
+    |
+        <MINUS> { return SqlStdOperatorTable.MINUS; }
+    |
+        <STAR> { return SqlStdOperatorTable.MULTIPLY; }
+    |
+        <SLASH> { return SqlStdOperatorTable.DIVIDE; }
+    |
+        <PERCENT_REMAINDER> {
+            if (!this.conformance.isPercentRemainderAllowed()) {
+                throw SqlUtil.newContextException(getPos(),
+                    RESOURCE.percentRemainderNotAllowed());
+            }
+            return SqlStdOperatorTable.PERCENT_REMAINDER;
+        }
+    |
+        <CONCAT> { return SqlStdOperatorTable.CONCAT; }
+    |
+        <AND> { return SqlStdOperatorTable.AND; }
+    |
+        <OR> { return SqlStdOperatorTable.OR; }
+    |
+        LOOKAHEAD(2) <IS> <DISTINCT> <FROM> {
+            return SqlStdOperatorTable.IS_DISTINCT_FROM;
+        }
+    |
+        <IS> <NOT> <DISTINCT> <FROM> {
+            return SqlStdOperatorTable.IS_NOT_DISTINCT_FROM;
+        }
+    |
+        <MEMBER> <OF> { return SqlStdOperatorTable.MEMBER_OF; }
+    |
+        LOOKAHEAD(2) <SUBMULTISET> <OF> {
+            return SqlStdOperatorTable.SUBMULTISET_OF;
+        }
+    |
+        <NOT> <SUBMULTISET> <OF> {
+            return SqlStdOperatorTable.NOT_SUBMULTISET_OF;
+        }
+    |
+        <CONTAINS> { return SqlStdOperatorTable.CONTAINS; }
+    |
+        <OVERLAPS> { return SqlStdOperatorTable.OVERLAPS; }
+    |
+        <EQUALS> { return SqlStdOperatorTable.PERIOD_EQUALS; }
+    |
+        <PRECEDES> { return SqlStdOperatorTable.PRECEDES; }
+    |
+        <SUCCEEDS> { return SqlStdOperatorTable.SUCCEEDS; }
+    |
+        LOOKAHEAD(2) <IMMEDIATELY> <PRECEDES> {
+            return SqlStdOperatorTable.IMMEDIATELY_PRECEDES;
+        }
+    |
+        <IMMEDIATELY> <SUCCEEDS> {
+            return SqlStdOperatorTable.IMMEDIATELY_SUCCEEDS;
+        }
+    |
+        op = BinaryMultisetOperator() { return op; }
+    )
+}
+
+/**
  * Parses a binary row expression, or a parenthesized expression of any
  * kind.
  *
@@ -3045,7 +3148,7 @@ List<Object> Expression2(ExprContext exprContext) :
                     checkNonQueryExpression(exprContext);
                 }
                 (
-                    <NOT> <IN> { op = SqlStdOperatorTable.NOT_IN; }
+                    ( <NOT> | <CARET>) <IN> { op = SqlStdOperatorTable.NOT_IN; }
                 |
                     <IN> { op = SqlStdOperatorTable.IN; }
                 |
@@ -3118,7 +3221,7 @@ List<Object> Expression2(ExprContext exprContext) :
                 |
                     (
                         (
-                            <NOT>
+                            ( <NOT> | <CARET>)
                             (
                                 <LIKE> { op = SqlStdOperatorTable.NOT_LIKE; }
                             |

--- a/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
@@ -3015,9 +3015,11 @@ SqlBinaryOperator BinaryRowOperator() :
     SqlBinaryOperator op;
 }
 {
-    // <IN> is handled as a special case
+    // <IN> and <LIKE> are handled as special cases
     (
-        <EQ> { return SqlStdOperatorTable.EQUALS; }
+        ( <EQ> | ( <CARET> | <NOT> ) <NE> ) {
+            return SqlStdOperatorTable.EQUALS;
+        }
     |
         ( <GT> | ( <CARET> | <NOT> ) <LE> ) {
             return SqlStdOperatorTable.GREATER_THAN;

--- a/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
@@ -3019,23 +3019,23 @@ SqlBinaryOperator BinaryRowOperator() :
     (
         <EQ> { return SqlStdOperatorTable.EQUALS; }
     |
-        ( <GT> | (<CARET> | <NOT>) <LE> ) {
+        ( <GT> | ( <CARET> | <NOT> ) <LE> ) {
             return SqlStdOperatorTable.GREATER_THAN;
         }
     |
-        ( <LT> | (<CARET> | <NOT>) <GE> ) {
+        ( <LT> | ( <CARET> | <NOT> ) <GE> ) {
             return SqlStdOperatorTable.LESS_THAN;
         }
     |
-        ( <LE> | (<CARET> | <NOT>) <GT> ) {
+        ( <LE> | ( <CARET> | <NOT> ) <GT> ) {
             return SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
         }
     |
-        ( <GE> | (<CARET> | <NOT>) <LT> ) {
+        ( <GE> | ( <CARET> | <NOT> ) <LT> ) {
             return SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
         }
     |
-        ( <NE> | (<CARET> | <NOT>) <EQ> )
+        ( <NE> | ( <CARET> | <NOT> ) <EQ> )
         {
             return SqlStdOperatorTable.NOT_EQUALS;
         }
@@ -3148,7 +3148,7 @@ List<Object> Expression2(ExprContext exprContext) :
                     checkNonQueryExpression(exprContext);
                 }
                 (
-                    ( <NOT> | <CARET>) <IN> { op = SqlStdOperatorTable.NOT_IN; }
+                    ( <NOT> | <CARET> ) <IN> { op = SqlStdOperatorTable.NOT_IN; }
                 |
                     <IN> { op = SqlStdOperatorTable.IN; }
                 |
@@ -3221,7 +3221,7 @@ List<Object> Expression2(ExprContext exprContext) :
                 |
                     (
                         (
-                            ( <NOT> | <CARET>)
+                            ( <NOT> | <CARET> )
                             (
                                 <LIKE> { op = SqlStdOperatorTable.NOT_LIKE; }
                             |

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3882,6 +3882,7 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  // TODO: Add failing test cases for queries with NOT and "^" together
   @Test public void testCaretNegation() {
     String sql = "select * from foo where ^a = 1";
     String expected = "SELECT *\n"

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3930,6 +3930,14 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testCaretNegationNotEquals() {
+    String sql = "select * from foo where a ^<> 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` = 1)";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testCaretNegationLessThan() {
     String sql = "select * from foo where a ^< 1";
     String expected = "SELECT *\n"
@@ -3983,6 +3991,14 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     String expected = "SELECT *\n"
         + "FROM `FOO`\n"
         + "WHERE (`A` <> 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testNotWithNotEquals() {
+    String sql = "select * from foo where a not <> 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` = 1)";
     sql(sql).ok(expected);
   }
 

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3922,6 +3922,102 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testCaretNegationEquals() {
+    String sql = "select * from foo where a ^= 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` <> 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCaretNegationLessThan() {
+    String sql = "select * from foo where a ^< 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` >= 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCaretNegationGreaterThan() {
+    String sql = "select * from foo where a ^> 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` <= 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCaretNegationLessThanOrEqualTo() {
+    String sql = "select * from foo where a ^<= 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` > 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCaretNegationGreaterThanOrEqualTo() {
+    String sql = "select * from foo where a ^>= 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` < 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCaretNegationIn() {
+    String sql = "select * from emp where deptno ^ in (10, 20)";
+    String expected = "SELECT *\n"
+        + "FROM `EMP`\n"
+        + "WHERE (`DEPTNO` NOT IN (10, 20))";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testCaretNegationLike() {
+    String sql = "select * from emp where deptno ^ LIKE 10";
+    String expected = "SELECT *\n"
+        + "FROM `EMP`\n"
+        + "WHERE (`DEPTNO` NOT LIKE 10)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testNotEquals() {
+    String sql = "select * from foo where a not = 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` <> 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testNotLessThan() {
+    String sql = "select * from foo where a not < 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` >= 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testNotGreaterThan() {
+    String sql = "select * from foo where a not > 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` <= 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testNotLessThanOrEqualTo() {
+    String sql = "select * from foo where a not <= 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` > 1)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testNotGreaterThanOrEqualTo() {
+    String sql = "select * from foo where a not >= 1";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`\n"
+        + "WHERE (`A` < 1)";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testCreateProcedure() {
     final String sql = "create procedure foo () select bar";
     final String expected = "CREATE PROCEDURE `FOO` () SELECT `BAR`";


### PR DESCRIPTION
 - BinaryRowOperator overridden in Dialect1
 - Added support for caret negation operator "^" before` =, <, >, <=, >=, LIKE, IN`.
 - Added support for NOT before `=, <, >, <=, >=`
 - Unparses to equivalent existing operator