### PR TITLE
[CALCITE] Allow '#' and '$' tokens in identifiers

### DIFF
--- a/parsing/dialects/intermediate/dialects/defaultdialect/src/test/java/org/apache/calcite/test/DefaultDialectParserTest.java
+++ b/parsing/dialects/intermediate/dialects/defaultdialect/src/test/java/org/apache/calcite/test/DefaultDialectParserTest.java
@@ -46,4 +46,12 @@ final class DefaultDialectParserTest extends SqlDialectParserTest {
         + "having count(*) > 5 and deptno < 4 ^group^ by deptno, emp";
     sql(sql).fails("(?s).*Encountered \"group\" at .*");
   }
+
+  @Test void testInvalidToken() {
+    // Causes problems to the test infrastructure because the token mgr
+    // throws a java.lang.Error. The usual case is that the parser throws
+    // an exception.
+    sql("values (a^#^b)")
+        .fails("Lexical error at line 1, column 10\\.  Encountered: \"#\" \\(35\\), after : \"\"");
+  }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -4087,4 +4087,18 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
         + "TIME ZONE 'gmt'";
     sql(sql).ok(expected);
   }
+
+  @Test public void testIdentifierWithNumberSign() {
+    final String sql = "select * from #foo";
+    final String expected = "SELECT *\n"
+        + "FROM `#FOO`";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testIdentifierWithDollarSign() {
+    final String sql = "select * from $foo";
+    final String expected = "SELECT *\n"
+        + "FROM `$FOO`";
+    sql(sql).ok(expected);
+  }
 }

--- a/parsing/src/main/resources/Parser.jj
+++ b/parsing/src/main/resources/Parser.jj
@@ -647,6 +647,7 @@ of the 'normal states'.
 |   < VERTICAL_BAR: "|" >
 |   < CARET: "^" >
 |   < DOLLAR: "$" >
+|   < NUMBER_SIGN: "#" >
 }
 
 /* COMMENTS */
@@ -741,7 +742,7 @@ MORE :
     ("$" (<LETTER>|<DIGIT>|"_")+)?
     >
 |
-    < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>)* >
+    < IDENTIFIER: (<LETTER>|<DOLLAR>|<NUMBER_SIGN>) (<LETTER>|<DOLLAR>|<NUMBER_SIGN>|<DIGIT>)* >
 |
     < UNICODE_QUOTED_IDENTIFIER: "U" "&" <QUOTED_IDENTIFIER> >
 |

--- a/parsing/src/test/java/org/apache/calcite/test/SqlDialectParserTest.java
+++ b/parsing/src/test/java/org/apache/calcite/test/SqlDialectParserTest.java
@@ -710,14 +710,6 @@ public abstract class SqlDialectParserTest {
             + ".*");
   }
 
-  @Test void testInvalidToken() {
-    // Causes problems to the test infrastructure because the token mgr
-    // throws a java.lang.Error. The usual case is that the parser throws
-    // an exception.
-    sql("values (a^#^b)")
-        .fails("Lexical error at line 1, column 10\\.  Encountered: \"#\" \\(35\\), after : \"\"");
-  }
-
   // TODO: should fail in parser
   @Test void testStarAsFails() {
     sql("select * as x from emp")


### PR DESCRIPTION
[CALCITE] Allow '#' and '$' tokens in identifiers
