### PR TITLE
[CALCITE] Handle ambiguous column resolution for unknown tables.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
@@ -216,8 +216,9 @@ public abstract class ListScope extends DelegatingScope {
         found++;
         if (child.namespace.getType() instanceof UnknownRecordType) {
           unknownFound++;
-          // If table is unknown, only set {@code type} to ANY if it has not already been set.
-          // This ensures that the column will be resolved to a known (non-ANY) type if possible.
+          // If table is unknown, only set {@code type} to ANY if it has not
+          // already been set. This ensures that the column will be resolved to
+          // a known (non-ANY) type if possible.
           if (type == null) {
             type = field.getType();
           }
@@ -232,11 +233,14 @@ public abstract class ListScope extends DelegatingScope {
     case 1:
       return type;
     default:
-      // Only return type if unknown tables are allowed, and at most one of the matched tables
-      // is a known table (if more than one known table is matched, then the column would be
-      // ambiguous even with full schema information). If more than one unknown table is matched,
-      // it doesn't matter which one the column actually comes from, since the column type is ANY.
-      if (validator.config().allowUnknownTables() && found - unknownFound <= 1) {
+      // Only return type if unknown tables are allowed, and at most one of the
+      // matched tables is a known table (if more than one known table is
+      // matched, then the column would be ambiguous even with full schema
+      // information). If more than one unknown table is matched, it doesn't
+      // matter which one the column actually comes from, since the column type
+      // is ANY.
+      if (validator.config().allowUnknownTables()
+          && found - unknownFound <= 1) {
         return type;
       }
       throw validator.newValidationError(ctx,

--- a/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/ListScope.java
@@ -19,6 +19,7 @@ package org.apache.calcite.sql.validate;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.StructKind;
+import org.apache.calcite.rel.type.UnknownRecordType;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -204,6 +205,7 @@ public abstract class ListScope extends DelegatingScope {
   public RelDataType resolveColumn(String columnName, SqlNode ctx) {
     final SqlNameMatcher nameMatcher = validator.catalogReader.nameMatcher();
     int found = 0;
+    int unknownFound = 0;
     RelDataType type = null;
     for (ScopeChild child : children) {
       SqlValidatorNamespace childNs = child.namespace;
@@ -212,7 +214,16 @@ public abstract class ListScope extends DelegatingScope {
           nameMatcher.field(childRowType, columnName);
       if (field != null) {
         found++;
-        type = field.getType();
+        if (child.namespace.getType() instanceof UnknownRecordType) {
+          unknownFound++;
+          // If table is unknown, only set {@code type} to ANY if it has not already been set.
+          // This ensures that the column will be resolved to a known (non-ANY) type if possible.
+          if (type == null) {
+            type = field.getType();
+          }
+        } else {
+          type = field.getType();
+        }
       }
     }
     switch (found) {
@@ -221,9 +232,15 @@ public abstract class ListScope extends DelegatingScope {
     case 1:
       return type;
     default:
+      // Only return type if unknown tables are allowed, and at most one of the matched tables
+      // is a known table (if more than one known table is matched, then the column would be
+      // ambiguous even with full schema information). If more than one unknown table is matched,
+      // it doesn't matter which one the column actually comes from, since the column type is ANY.
+      if (validator.config().allowUnknownTables() && found - unknownFound <= 1) {
+        return type;
+      }
       throw validator.newValidationError(ctx,
           RESOURCE.columnAmbiguous(columnName));
     }
   }
-
 }


### PR DESCRIPTION
Modifies column resolution for unknown columns, so that unknown columns are not attributed to arbitrary unknown tables.