### PR TITLE
[CALCITE] DELETE join condition form

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -835,8 +835,8 @@ public class RelToSqlConverter extends SqlImplementor
       final Result input = visitChild(0, modify.getInput());
 
       final SqlDelete sqlDelete =
-          new SqlDelete(POS, sqlTargetTable,
-              input.asSelect().getWhere(), input.asSelect(), null);
+          new SqlDelete(POS, /*deleteTableName=*/null, sqlTargetTable,
+              /*alias=*/null, input.asSelect().getWhere(), input.asSelect());
 
       return result(sqlDelete, input.clauses, modify, null);
     }

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3781,7 +3781,7 @@ public class SqlToRelConverter {
 
   private RelNode convertDelete(SqlDelete call) {
     RelOptTable targetTable = getTargetTable(call);
-    RelNode sourceRel = convertSelect(call.getSourceSelect(), false);
+    RelNode sourceRel = convertSelect(call.sourceSelect, false);
     return LogicalTableModify.create(targetTable, catalogReader, sourceRel,
         LogicalTableModify.Operation.DELETE, null, null, false);
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -57,6 +57,7 @@ import org.apache.calcite.rel.rules.ProjectToCalcRule;
 import org.apache.calcite.sql.SqlDelete;
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlMerge;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlTableRef;
 import org.apache.calcite.sql.SqlUpdate;
@@ -281,8 +282,9 @@ class SqlHintsConverterTest extends SqlToRelTestBase {
   @Test void testTableHintsInDelete() throws Exception {
     final String sql = HintTools.withHint("delete from emp /*+ %s */ where deptno = 1");
     final SqlDelete sqlDelete = (SqlDelete) tester.parseQuery(sql);
-    assert sqlDelete.getTargetTable() instanceof SqlTableRef;
-    final SqlTableRef tableRef = (SqlTableRef) sqlDelete.getTargetTable();
+    SqlNode table = sqlDelete.tables.get(0);
+    assert table instanceof SqlTableRef;
+    final SqlTableRef tableRef = (SqlTableRef) table;
     List<RelHint> hints = SqlUtil.getRelHint(HintTools.HINT_STRATEGY_TABLE,
         (SqlNodeList) tableRef.getOperandList().get(1));
     assertHintsEquals(

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -103,45 +103,59 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
   }
 
   @Test void testDel() {
-    final String sql = "del from t";
-    final String expected = "DELETE FROM `T`";
-    sql(sql).ok(expected);
-  }
-
-  @Test void testDeleteWithoutFrom() {
-    final String sql = "delete t";
-    final String expected = "DELETE FROM `T`";
-    sql(sql).ok(expected);
-  }
-
-  @Test public void testDeleteWithTable() {
-    final String sql = "delete foo from bar";
+    final String sql = "del from foo";
     final String expected = "DELETE FROM `FOO`";
     sql(sql).ok(expected);
   }
 
-  @Test public void testDeleteWithTableCompoundIdentifier() {
+  @Test void testDeleteWithoutFrom() {
+    final String sql = "delete foo";
+    final String expected = "DELETE FROM `FOO`";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testDeleteWithDeleteTableName() {
+    final String sql = "delete foo from bar";
+    final String expected = "DELETE `FOO` FROM `BAR`";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testDeleteWithCompoundDeleteTableName() {
     final String sql = "delete foo.bar from baz";
-    final String expected = "DELETE FROM `FOO`.`BAR`";
+    final String expected = "DELETE `FOO`.`BAR` FROM `BAZ`";
     sql(sql).ok(expected);
   }
 
-  @Test public void testDeleteWithTableWithAlias() {
+  @Test public void testDeleteWithDeleteTableNameAndAlias() {
     final String sql = "delete foo from bar as b";
-    final String expected = "DELETE FROM `FOO` AS `B`";
+    final String expected = "DELETE `FOO` FROM `BAR` AS `B`";
     sql(sql).ok(expected);
   }
 
-  @Test public void testDeleteWithTableWithWhere() {
+  @Test public void testDeleteWithDeleteTableNameAndWhere() {
     final String sql = "delete foo from bar where bar.x = 0";
-    final String expected = "DELETE FROM `FOO`\n"
+    final String expected = "DELETE `FOO` FROM `BAR`\n"
         + "WHERE (`BAR`.`X` = 0)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testDeleteWithDeleteTableNameAndJoinAndWhere() {
+    final String sql = "delete foo from bar, baz where bar.x = baz.x";
+    final String expected = "DELETE `FOO` FROM `BAR`, `BAZ`\n"
+        + "WHERE (`BAR`.`X` = `BAZ`.`X`)";
+    sql(sql).ok(expected);
+  }
+
+  @Test public void testDeleteWithDeleteTableNameAndJoinAndAliasesAndWhere() {
+    final String sql = "delete foo from bar a, baz b where a.x = b.x";
+    final String expected = "DELETE `FOO` FROM `BAR` AS `A`, `BAZ` AS `B`\n"
+        + "WHERE (`A`.`X` = `B`.`X`)";
     sql(sql).ok(expected);
   }
 
   @Test public void testDeleteWithTableWithoutFrom() {
     final String sql = "delete foo bar";
-    final String expected = "DELETE FROM `FOO`";
+    final String expected = "DELETE `FOO` FROM `BAR`";
     sql(sql).ok(expected);
   }
 

--- a/parsing/parserImpls.ftl
+++ b/parsing/parserImpls.ftl
@@ -1119,8 +1119,8 @@ SqlNode SqlDelete() :
     [ [ <AS> ] alias = SimpleIdentifier() ]
     condition = WhereOpt()
     {
-        return new SqlDelete(s.add(table).addIf(extendList).addIf(alias)
-            .addIf(condition).pos(), table, condition, null, alias);
+        return new SqlDelete(s.end(this), /*deleteTableName=*/null, table,
+            alias, condition, /*sourceSelect=*/null);
     }
 }
 


### PR DESCRIPTION
This adds support for the following syntax to Dialect1:
DELETE <delete_table_name> <table_name> FROM <table_name> [AS <alias>] (, <table_name> [AS <alias>])*;