### PR TITLE
[CALCITE] Replaced calls of SourceTableAndAlias() to TableRef()

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -827,7 +827,7 @@ public class RelToSqlConverter extends SqlImplementor
               identifierList(modify.getUpdateColumnList()),
               exprList(context, modify.getSourceExpressionList()),
               ((SqlSelect) input.node).getWhere(), input.asSelect(),
-              null, /* sourceTables= */null, /* sourceAliases= */null);
+              null);
 
       return result(sqlUpdate, input.clauses, modify, null);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -506,16 +506,9 @@ public class SqlDialect {
     if (updateCall.getSourceTables() != null) {
       writer.keyword("FROM");
       final SqlWriter.Frame fromFrame = writer.startList("", "");
-      for (Pair<SqlNode, SqlNode> pair
-          : Pair.zip(updateCall.getSourceTables(), updateCall.getSourceAliases())) {
+      for (SqlNode sourceTable : updateCall.getSourceTables()) {
         writer.sep(",");
-        SqlNode sourceTable = pair.left;
         sourceTable.unparse(writer, opLeft, opRight);
-        SqlNode sourceAlias = pair.right;
-        if (sourceAlias != null) {
-          writer.keyword("AS");
-          sourceAlias.unparse(writer, opLeft, opRight);
-        }
       }
       writer.endList(fromFrame);
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -39,7 +39,6 @@ public class SqlUpdate extends SqlCall {
   SqlSelect sourceSelect;
   SqlIdentifier alias;
   SqlNodeList sourceTables;
-  SqlNodeList sourceAliases;
 
   //~ Constructors -----------------------------------------------------------
 
@@ -51,7 +50,7 @@ public class SqlUpdate extends SqlCall {
       SqlSelect sourceSelect,
       SqlIdentifier alias) {
     this(pos, targetTable, targetColumnList, sourceExpressionList, condition, sourceSelect, alias,
-        /*sourceTables=*/ null, /*sourceAliases=*/ null);
+        /*sourceTables=*/ null);
   }
 
   public SqlUpdate(SqlParserPos pos,
@@ -61,8 +60,7 @@ public class SqlUpdate extends SqlCall {
       SqlNode condition,
       SqlSelect sourceSelect,
       SqlIdentifier alias,
-      SqlNodeList sourceTables,
-      SqlNodeList sourceAliases) {
+      SqlNodeList sourceTables) {
     super(pos);
     this.targetTable = targetTable;
     this.targetColumnList = targetColumnList;
@@ -72,11 +70,6 @@ public class SqlUpdate extends SqlCall {
     assert sourceExpressionList.size() == targetColumnList.size();
     this.alias = alias;
     this.sourceTables = sourceTables;
-    this.sourceAliases = sourceAliases;
-    if (sourceTables != null) {
-      assert this.sourceAliases != null;
-      assert this.sourceTables.size() == this.sourceAliases.size();
-    }
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -188,13 +181,6 @@ public class SqlUpdate extends SqlCall {
    */
   public SqlNodeList getSourceTables() {
     return sourceTables;
-  }
-
-  /**
-   * @return the source table aliases
-   */
-  public SqlNodeList getSourceAliases() {
-    return sourceAliases;
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -84,7 +84,7 @@ public class SqlUpdate extends SqlCall {
 
   public List<SqlNode> getOperandList() {
     return ImmutableNullableList.of(targetTable, targetColumnList,
-        sourceExpressionList, condition, alias, sourceTables, sourceAliases);
+        sourceExpressionList, condition, alias, sourceTables);
   }
 
   @Override public void setOperand(int i, SqlNode operand) {
@@ -110,9 +110,6 @@ public class SqlUpdate extends SqlCall {
       break;
     case 6:
       sourceTables = (SqlNodeList) operand;
-      break;
-    case 7:
-      sourceAliases = (SqlNodeList) operand;
       break;
     default:
       throw new AssertionError(i);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -178,16 +178,9 @@ public class BigQuerySqlDialect extends SqlDialect {
     if (updateCall.getSourceTables() != null) {
       writer.keyword("FROM");
       final SqlWriter.Frame fromFrame = writer.startList("", "");
-      for (Pair<SqlNode, SqlNode> pair
-          : Pair.zip(updateCall.getSourceTables(), updateCall.getSourceAliases())) {
+      for (SqlNode sourceTable : updateCall.getSourceTables()) {
         writer.sep(",");
-        SqlNode sourceTable = pair.left;
         sourceTable.unparse(writer, opLeft, opRight);
-        SqlNode sourceAlias = pair.right;
-        if (sourceAlias != null) {
-          writer.keyword("AS");
-          sourceAlias.unparse(writer, opLeft, opRight);
-        }
       }
       writer.endList(fromFrame);
     }

--- a/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
@@ -2949,6 +2949,7 @@ SqlNode SqlUpdate() :
     SqlIdentifier id;
     SqlNode exp;
     final Span s;
+    SqlNode e;
 }
 {
     (
@@ -2974,11 +2975,15 @@ SqlNode SqlUpdate() :
                 sourceTables = new SqlNodeList(s.pos());
                 sourceAliases = new SqlNodeList(s.pos());
             }
-            SourceTableAndAlias(sourceTables, sourceAliases)
+            e = TableRef() {
+                sourceTables.add(e);
+            }
         )
         (
             <COMMA>
-            SourceTableAndAlias(sourceTables, sourceAliases)
+            e = TableRef() {
+                sourceTables.add(e);
+            }
         )*
     ]
     /* CompoundIdentifier() can read statements like FOO.X, SimpleIdentifier()

--- a/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
@@ -154,25 +154,6 @@ SqlNodeList ExtendColumnList() :
     }
 }
 
-void SourceTableAndAlias(SqlNodeList tables, SqlNodeList aliases) :
-{
-    SqlNode table;
-    SqlIdentifier alias;
-}
-{
-    table = TableRef() {
-        tables.add(table);
-    }
-    (
-        [ <AS> ]
-        alias = SimpleIdentifier() {
-            aliases.add(alias);
-        }
-    |
-        { aliases.add(null); }
-    )
-}
-
 // The DateTime functions are singled out to allow for arguments to
 // be parsed, such as CURRENT_DATE(0).
 SqlColumnAttribute ColumnAttributeDefault() :
@@ -2940,7 +2921,6 @@ SqlNode SqlUpdate() :
 {
     SqlNode table;
     SqlNodeList sourceTables = null;
-    SqlNodeList sourceAliases = null;
     SqlNodeList extendList = null;
     SqlIdentifier alias = null;
     SqlNode condition;
@@ -2973,7 +2953,6 @@ SqlNode SqlUpdate() :
         (
             <FROM> {
                 sourceTables = new SqlNodeList(s.pos());
-                sourceAliases = new SqlNodeList(s.pos());
             }
             e = TableRef() {
                 sourceTables.add(e);
@@ -3012,7 +2991,7 @@ SqlNode SqlUpdate() :
         return new SqlUpdate(s.addAll(targetColumnList)
             .addAll(sourceExpressionList).addIf(condition).pos(), table,
             targetColumnList, sourceExpressionList, condition, null, alias,
-            sourceTables, sourceAliases);
+            sourceTables);
     }
 }
 

--- a/parsing/parserImpls.ftl
+++ b/parsing/parserImpls.ftl
@@ -1178,8 +1178,7 @@ SqlNode SqlUpdate() :
     {
         return new SqlUpdate(s.addAll(targetColumnList)
             .addAll(sourceExpressionList).addIf(condition).pos(), table,
-            targetColumnList, sourceExpressionList, condition, null, alias,
-            null, null);
+            targetColumnList, sourceExpressionList, condition, null, alias);
     }
 }
 
@@ -1248,8 +1247,7 @@ SqlUpdate WhenMatchedClause(SqlNode table, SqlIdentifier alias) :
     )*
     {
         return new SqlUpdate(s.addAll(updateExprList).pos(), table,
-            updateColumnList, updateExprList, null, null, alias,
-            /*secondTable=*/ null, /*secondAlias=*/ null);
+            updateColumnList, updateExprList, null, null, alias);
     }
 }
 


### PR DESCRIPTION
When this feature was first added it was overlooked that TableRef() can also parse aliases. 