### PR TITLE
[CALCITE] Support for optionally parenthesized FROM clauses and table references.

### DIFF
--- a/parsing/intermediate/dialects/defaultdialect/src/test/java/org/apache/calcite/test/DefaultDialectParserTest.java
+++ b/parsing/intermediate/dialects/defaultdialect/src/test/java/org/apache/calcite/test/DefaultDialectParserTest.java
@@ -47,13 +47,5 @@ final class DefaultDialectParserTest extends SqlDialectParserTest {
     // <table-name> may not occur within parentheses.
     sql("select * from (^emp^) as x")
         .fails("(?s)Non-query expression encountered in illegal context.*");
-
-    // Parentheses around JOINs are OK, and sometimes necessary.
-    if (false) {
-      // todo:
-      sql("select * from (emp join dept using (deptno))").ok("xx");
-
-      sql("select * from (emp join dept using (deptno)) join foo using (x)").ok("xx");
-    }
   }
 }

--- a/parsing/intermediate/dialects/defaultdialect/src/test/java/org/apache/calcite/test/DefaultDialectParserTest.java
+++ b/parsing/intermediate/dialects/defaultdialect/src/test/java/org/apache/calcite/test/DefaultDialectParserTest.java
@@ -30,8 +30,7 @@ final class DefaultDialectParserTest extends SqlDialectParserTest {
     return DefaultDialectParserImpl.FACTORY;
   }
 
-  @Test
-  void testParensInFrom() {
+  @Test void testParensInFrom() {
     // UNNEST may not occur within parentheses.
     // FIXME should fail at "unnest"
     sql("select *from ^(^unnest(x))")

--- a/parsing/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/intermediate/dialects/dialect1/parserImpls.ftl
@@ -2658,7 +2658,7 @@ SqlNode OptionallyParenthesizedTableRef(boolean lateral) :
     (
         LOOKAHEAD( <LPAREN> TableRefWithHintsOpt() <RPAREN> )
         <LPAREN>
-        tableRef = TableRefWithHintsOpt()
+        tableRef = TableRef2(lateral)
         <RPAREN>
     |
         tableRef = TableRef2(lateral)

--- a/parsing/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/intermediate/dialects/dialect1/parserImpls.ftl
@@ -2590,57 +2590,6 @@ SqlSelect SqlSelect() :
     }
 }
 
-/** Matches "LEFT JOIN t ON ...", "RIGHT JOIN t USING ...", "JOIN t". */
-SqlNode JoinClause(SqlNode e) :
-{
-    SqlNode e2, condition;
-    final SqlLiteral natural, joinType, joinConditionType;
-    SqlNodeList list;
-}
-{
-    natural = Natural()
-    joinType = JoinType()
-    e2 = TableRefOrJoinClause()
-    (
-        <ON> {
-            joinConditionType = JoinConditionType.ON.symbol(getPos());
-        }
-        condition = Expression(ExprContext.ACCEPT_SUB_QUERY) {
-            return new SqlJoin(joinType.getParserPosition(),
-                e,
-                natural,
-                joinType,
-                e2,
-                joinConditionType,
-                condition);
-        }
-    |
-        <USING> {
-            joinConditionType = JoinConditionType.USING.symbol(getPos());
-        }
-        list = ParenthesizedSimpleIdentifierList() {
-            return new SqlJoin(joinType.getParserPosition(),
-                e,
-                natural,
-                joinType,
-                e2,
-                joinConditionType,
-                new SqlNodeList(list.getList(),
-                Span.of(joinConditionType).end(this)));
-        }
-    |
-        {
-            return new SqlJoin(joinType.getParserPosition(),
-                e,
-                natural,
-                joinType,
-                e2,
-                JoinConditionType.NONE.symbol(joinType.getParserPosition()),
-                null);
-        }
-    )
-}
-
 /**
  * Parses either a table reference, or a parenthesized table reference.
  * Due to deficiencies of JavaCC's nested syntactic LOOKAHEADs, only simple

--- a/parsing/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/intermediate/dialects/dialect1/parserImpls.ftl
@@ -2665,7 +2665,7 @@ SqlNode OptionallyParenthesizedFromClause() :
 }
 {
     (
-
+        LOOKAHEAD( FromClause() )
         fromClause = FromClause()
     |
         <LPAREN>

--- a/parsing/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3623,14 +3623,14 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
   @Test public void testParenthesizedFromClauseTableRef() {
     final String sql = "select * from (foo)";
     final String expected = "SELECT *\n"
-        +"FROM `FOO`";
+        + "FROM `FOO`";
     sql(sql).ok(expected);
   }
 
   @Test public void testParenthesizedFromClauseTableRefWithAlias() {
     final String sql = "select * from (foo as f)";
     final String expected = "SELECT *\n"
-        +"FROM `FOO` AS `F`";
+        + "FROM `FOO` AS `F`";
     sql(sql).ok(expected);
   }
 

--- a/parsing/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -3627,6 +3627,13 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testParenthesizedFromClauseTableRefWithAlias() {
+    final String sql = "select * from (foo as f)";
+    final String expected = "SELECT *\n"
+        +"FROM `FOO` AS `F`";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testParenthesizedFromClauseJoin() {
     final String sql = "select * from (foo inner join bar on foo.x = bar.x)";
     final String expected = "SELECT *\n"

--- a/parsing/src/test/java/org/apache/calcite/test/SqlDialectParserTest.java
+++ b/parsing/src/test/java/org/apache/calcite/test/SqlDialectParserTest.java
@@ -7173,33 +7173,6 @@ public abstract class SqlDialectParserTest {
         .fails("(?s)Encountered \"with\" at .*");
   }
 
-  @Test void testParensInFrom() {
-    // UNNEST may not occur within parentheses.
-    // FIXME should fail at "unnest"
-    sql("select *from ^(^unnest(x))")
-        .fails("(?s)Encountered \"\\( unnest\" at .*");
-
-    // <table-name> may not occur within parentheses.
-    sql("select * from (^emp^)")
-        .fails("(?s)Non-query expression encountered in illegal context.*");
-
-    // <table-name> may not occur within parentheses.
-    sql("select * from (^emp^ as x)")
-        .fails("(?s)Non-query expression encountered in illegal context.*");
-
-    // <table-name> may not occur within parentheses.
-    sql("select * from (^emp^) as x")
-        .fails("(?s)Non-query expression encountered in illegal context.*");
-
-    // Parentheses around JOINs are OK, and sometimes necessary.
-    if (false) {
-      // todo:
-      sql("select * from (emp join dept using (deptno))").ok("xx");
-
-      sql("select * from (emp join dept using (deptno)) join foo using (x)").ok("xx");
-    }
-  }
-
   @Test void testProcedureCall() {
     sql("call blubber(5)")
         .ok("CALL `BLUBBER`(5)");


### PR DESCRIPTION
Supports optional parentheses like 
SELECT * FROM (foo CROSS JOIN bar)
SELECT * FROM (foo) CROSS JOIN bar
Only simple parenthesized table refs are supported.
OptionallyParenthesizedFromClause and OptionallyParenthesizedTableRef are new methods
FromClause, JoinClause, and TableRefOrJoinClause are overrides (with OptionallyParenthesized__() methods inserted).