### PR TITLE
[CALCITE] Fix inline MOD validation on subqueries

### DIFF
--- a/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
+++ b/parsing/dialects/intermediate/dialects/dialect1/parserImpls.ftl
@@ -1509,17 +1509,13 @@ SqlNode InlineModOperatorLiteralOrIdentifier() :
 SqlNode InlineModOperator(SqlNode q) :
 {
     final List<SqlNode> args = new ArrayList<SqlNode>();
-    final SqlIdentifier qualifiedName;
     final Span s;
     SqlNode e;
-    SqlFunctionCategory funcType = SqlFunctionCategory.USER_DEFINED_FUNCTION;
-    SqlLiteral quantifier = null;
 }
 {
     <MOD> {
         s = span();
         args.add(q);
-        qualifiedName = new SqlIdentifier(unquotedIdentifier(), s.pos());
     }
     (
         e = NumericLiteral()
@@ -1527,10 +1523,11 @@ SqlNode InlineModOperator(SqlNode q) :
         e = CompoundIdentifier()
     |
         e = ParenthesizedQueryOrCommaList(ExprContext.ACCEPT_SUB_QUERY)
+        { e = ((SqlNodeList) e).get(0); }
     )
     {
         args.add(e);
-        return createCall(qualifiedName, s.end(this), funcType, quantifier, args);
+        return SqlStdOperatorTable.MOD.createCall(s.end(this), args);
     }
 }
 

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ParserTest.java
@@ -1623,33 +1623,33 @@ final class Dialect1ParserTest extends SqlDialectParserTest {
 
   @Test public void testInlineModSyntaxInteger() {
     final String sql = "select 27 mod -3";
-    final String expected = "SELECT MOD(27, -3)";
+    final String expected = "SELECT (MOD(27, -3))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineModSyntaxFloatingPoint() {
     final String sql = "select 27.123 mod 4.12";
-    final String expected = "SELECT MOD(27.123, 4.12)";
+    final String expected = "SELECT (MOD(27.123, 4.12))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineModSyntaxSimpleIdentifiers() {
     final String sql = "select foo mod bar";
-    final String expected = "SELECT MOD(`FOO`, `BAR`)";
+    final String expected = "SELECT (MOD(`FOO`, `BAR`))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineModSyntaxCompoundIdentifiers() {
     final String sql = "select foo.bar mod baz.qux";
-    final String expected = "SELECT MOD(`FOO`.`BAR`, `BAZ`.`QUX`)";
+    final String expected = "SELECT (MOD(`FOO`.`BAR`, `BAZ`.`QUX`))";
     sql(sql).ok(expected);
   }
 
   @Test public void testInlineModSyntaxExpressions() {
     final String sql = "select (select foo from bar) mod (select baz from qux)";
-    final String expected = "SELECT MOD((SELECT `FOO`\n"
+    final String expected = "SELECT (MOD((SELECT `FOO`\n"
         + "FROM `BAR`), (SELECT `BAZ`\n"
-        + "FROM `QUX`))";
+        + "FROM `QUX`)))";
     sql(sql).ok(expected);
   }
 

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -35,14 +35,14 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
             .with("allowUnknownTables", true));
   }
 
-  @Test public void testSelRewrite() {
+  @Test public void testSel() {
     String sql = "sel a from abc";
     String expected = "SELECT `ABC`.`A`\n"
         + "FROM `ABC` AS `ABC`";
     sql(sql).rewritesTo(expected);
   }
 
-  @Test public void testFirstValueRewrite() {
+  @Test public void testFirstValue() {
     String sql = "SELECT FIRST_VALUE (foo) OVER (PARTITION BY (foo)) FROM bar";
     String expected = "SELECT FIRST_VALUE(`BAR`.`FOO`) OVER (PARTITION BY "
         + "`BAR`.`FOO`)\n"
@@ -50,7 +50,7 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     sql(sql).rewritesTo(expected);
   }
 
-  @Test public void testLastValueRewrite() {
+  @Test public void testLastValue() {
     String sql = "SELECT LAST_VALUE (foo) OVER (PARTITION BY (foo)) FROM bar";
     String expected = "SELECT LAST_VALUE(`BAR`.`FOO`) OVER (PARTITION BY "
         + "`BAR`.`FOO`)\n"
@@ -58,7 +58,7 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     sql(sql).rewritesTo(expected);
   }
 
-  @Test public void testFirstValueIgnoreNullsRewrite() {
+  @Test public void testFirstValueIgnoreNulls() {
     final String sql = "SELECT FIRST_VALUE (foo IGNORE NULLS) OVER"
         + " (PARTITION BY (foo)) FROM bar";
     final String expected = "SELECT FIRST_VALUE(`BAR`.`FOO` IGNORE NULLS)"
@@ -90,6 +90,15 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     String sql = "select :a from abc";
     String expected = "SELECT :A\n"
         + "FROM `ABC` AS `ABC`";
+    sql(sql).rewritesTo(expected);
+  }
+
+  @Test public void testInlineModOperatorWithExpressions() {
+    String sql = "select (select a from abc) mod (select d from def) from ghi";
+    String expected = "SELECT MOD(((SELECT `ABC`.`A`\n"
+     + "FROM `ABC` AS `ABC`)), ((SELECT `DEF`.`D`\n"
+     + "FROM `DEF` AS `DEF`)))\n"
+     + "FROM `GHI` AS `GHI`";
     sql(sql).rewritesTo(expected);
   }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -96,9 +96,9 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
   @Test public void testInlineModOperatorWithExpressions() {
     String sql = "select (select a from abc) mod (select d from def) from ghi";
     String expected = "SELECT MOD(((SELECT `ABC`.`A`\n"
-     + "FROM `ABC` AS `ABC`)), ((SELECT `DEF`.`D`\n"
-     + "FROM `DEF` AS `DEF`)))\n"
-     + "FROM `GHI` AS `GHI`";
+        + "FROM `ABC` AS `ABC`)), ((SELECT `DEF`.`D`\n"
+        + "FROM `DEF` AS `DEF`)))\n"
+        + "FROM `GHI` AS `GHI`";
     sql(sql).rewritesTo(expected);
   }
 }


### PR DESCRIPTION
Updated the Dialect1 parsing logic to use the SqlStdOperatorTable.MOD built-in function. Also, fixed a bug when an expression was used in the second argument to the MOD operator.