### PR TITLE
[CALCITE] Extract schema for CREATE TABLE statements

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/impl/ExplicitRowTypeTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ExplicitRowTypeTable.java
@@ -28,9 +28,7 @@ public class ExplicitRowTypeTable extends AbstractTable {
     this.rowType = Objects.requireNonNull(rowType);
   }
 
-  @Override
-  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+  @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
     return this.rowType;
   }
 }
-

--- a/core/src/main/java/org/apache/calcite/schema/impl/ExplicitRowTypeTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/ExplicitRowTypeTable.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.impl;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+
+import java.util.Objects;
+
+public class ExplicitRowTypeTable extends AbstractTable {
+  private final RelDataType rowType;
+
+  public ExplicitRowTypeTable(RelDataType rowType) {
+    this.rowType = Objects.requireNonNull(rowType);
+  }
+
+  @Override
+  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    return this.rowType;
+  }
+}
+

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateTable.java
@@ -50,7 +50,6 @@ import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
-import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.sql2rel.InitializerContext;
 import org.apache.calcite.sql2rel.InitializerExpressionFactory;

--- a/core/src/main/java/org/apache/calcite/sql/SqlCreateTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCreateTable.java
@@ -50,6 +50,8 @@ import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.sql2rel.InitializerContext;
 import org.apache.calcite.sql2rel.InitializerExpressionFactory;
 import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
@@ -113,6 +115,12 @@ public class SqlCreateTable extends SqlCreate
       writer.newlineAndIndent();
       query.unparse(writer, 0, 0);
     }
+  }
+
+  public void validate(
+      SqlValidator validator,
+      SqlValidatorScope scope) {
+    validator.validateCreateTable(this);
   }
 
   public void execute(CalcitePrepare.Context context) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -24,6 +24,7 @@ import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.runtime.CalciteException;
 import org.apache.calcite.runtime.Resources;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCreateTable;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDelete;
 import org.apache.calcite.sql.SqlDynamicParam;
@@ -222,6 +223,13 @@ public interface SqlValidator {
    * @param qualifier Interval qualifier
    */
   void validateIntervalQualifier(SqlIntervalQualifier qualifier);
+
+  /**
+   * Validates a {@link SqlCreateTable}
+   *
+   * @param createTable The create table statement
+   */
+  void validateCreateTable(SqlCreateTable createTable);
 
   /**
    * Validates an INSERT statement.

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -225,7 +225,7 @@ public interface SqlValidator {
   void validateIntervalQualifier(SqlIntervalQualifier qualifier);
 
   /**
-   * Validates a {@link SqlCreateTable}
+   * Validates a {@link SqlCreateTable}.
    *
    * @param createTable The create table statement
    */

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3228,7 +3228,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   @Override public void validateCreateTable(SqlCreateTable createTable) {
-    assert createTable != null;
+    Preconditions.checkArgument(createTable != null);
     // Type doesn't matter for CREATE TABLE statements.
     nodeToTypeMap.put(createTable, unknownType);
     CalciteSchema schema = catalogReader.getRootSchema();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3229,7 +3229,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
   @Override public void validateCreateTable(SqlCreateTable createTable) {
     Preconditions.checkArgument(createTable != null);
-    // Type doesn't matter for CREATE TABLE statements.
+    // Type is not applicable for CREATE TABLE statements.
     nodeToTypeMap.put(createTable, unknownType);
     CalciteSchema schema = catalogReader.getRootSchema();
     RelDataTypeFactory.Builder builder = typeFactory.builder();

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3241,12 +3241,12 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     for (SqlNode column : createTable.columnList) {
       // This field is guaranteed to be of type SqlColumnDeclaration since this
       // is a SqlCreateTable node type.
-      assert column instanceof SqlColumnDeclaration;
+      Preconditions.checkArgument(column instanceof SqlColumnDeclaration);
       SqlColumnDeclaration col = (SqlColumnDeclaration) column;
       SqlTypeNameSpec typeNameSpec = col.dataType.getTypeNameSpec();
       // All data types that we initially plan to support (e.g. INTEGER, VARCHAR,
       // BOOLEAN, DATE, etc) are of type SqlBasicTypeNameSpec.
-      assert typeNameSpec instanceof SqlBasicTypeNameSpec;
+      Preconditions.checkArgument(typeNameSpec instanceof SqlBasicTypeNameSpec);
       SqlBasicTypeNameSpec basicTypeNameSpec =
         (SqlBasicTypeNameSpec) typeNameSpec;
       builder.add(col.name.toString(), basicTypeNameSpec.sqlTypeName);

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3248,7 +3248,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       // BOOLEAN, DATE, etc) are of type SqlBasicTypeNameSpec.
       Preconditions.checkArgument(typeNameSpec instanceof SqlBasicTypeNameSpec);
       SqlBasicTypeNameSpec basicTypeNameSpec =
-        (SqlBasicTypeNameSpec) typeNameSpec;
+          (SqlBasicTypeNameSpec) typeNameSpec;
       builder.add(col.name.toString(), basicTypeNameSpec.sqlTypeName);
     }
     schema.add(createTable.name.toString(),

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3229,7 +3229,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
   @Override public void validateCreateTable(SqlCreateTable createTable) {
     assert createTable != null;
-    setValidatedNodeType(createTable, unknownType);
+    // Type doesn't matter for CREATE TABLE statements.
+    nodeToTypeMap.put(createTable, unknownType);
     CalciteSchema schema = catalogReader.getRootSchema();
     RelDataTypeFactory.Builder builder = typeFactory.builder();
     if (createTable.columnList == null) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11127,9 +11127,4 @@ class SqlValidatorTest extends SqlValidatorTestCase {
         .withConformance(SqlConformanceEnum.LENIENT)
         .rewritesTo(expected);
   }
-
-  @Test public void testCreateTableNoColumns() {
-    String sql = "create table foo";
-    sql(sql).ok();
-  }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11127,4 +11127,9 @@ class SqlValidatorTest extends SqlValidatorTestCase {
         .withConformance(SqlConformanceEnum.LENIENT)
         .rewritesTo(expected);
   }
+
+  @Test public void testCreateTableNoColumns() {
+    String sql = "create table foo";
+    sql(sql).ok();
+  }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -101,9 +101,4 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + "FROM `GHI` AS `GHI`";
     sql(sql).rewritesTo(expected);
   }
-
-  @Test public void testCreateTable() {
-    String sql = "create table foo";
-    sql(sql).ok();
-  }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -109,24 +109,39 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     sql(query).type("RecordType() NOT NULL");
   }
 
-  @Test public void testCreateTableWithColumns() {
+  @Test public void testCreateTableSelectInteger() {
     String ddl = "create table foo(x int, y varchar)";
-    sql(ddl).ok();
-
     String query = "select x from foo";
+    sql(ddl).ok();
     sql(query).type("RecordType(INTEGER NOT NULL X) NOT NULL");
+  }
 
-    String query2 = "select y from foo";
-    sql(query2).type("RecordType(VARCHAR NOT NULL Y) NOT NULL");
+  @Test public void testCreateTableSelectVarchar() {
+    String ddl = "create table foo(x int, y varchar)";
+    String query = "select y from foo";
+    sql(ddl).ok();
+    sql(query).type("RecordType(VARCHAR NOT NULL Y) NOT NULL");
+  }
 
-    String query3 = "insert into foo values (1, 'str')";
-    sql(query3).type("RecordType(INTEGER NOT NULL X, VARCHAR NOT NULL Y)"
+  @Test public void testCreateTableInsert() {
+    String ddl = "create table foo(x int, y varchar)";
+    String query = "insert into foo values (1, 'str')";
+    sql(ddl).ok();
+    sql(query).type("RecordType(INTEGER NOT NULL X, VARCHAR NOT NULL Y)"
         + " NOT NULL");
+  }
 
-    String query4 = "insert into foo values (1, 'str', 1)";
-    sql(query4).fails("end index \\(3\\) must not be greater than size \\(2\\)");
+  @Test public void testCreateTableSelectNonExistingColumnFails() {
+    String ddl = "create table foo(x int, y varchar)";
+    String query = "select ^z^ from foo";
+    sql(ddl).ok();
+    sql(query).fails("Column 'Z' not found in any table");
+  }
 
-    String query5 = "select ^z^ from foo";
-    sql(query5).fails("Column 'Z' not found in any table");
+  @Test public void testCreateTableInsertTooManyValuesFails() {
+    String ddl = "create table foo(x int, y varchar)";
+    String query = "insert into foo values (1, 'str', 1)";
+    sql(ddl).ok();
+    sql(query).fails("end index \\(3\\) must not be greater than size \\(2\\)");
   }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -131,7 +131,7 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + " NOT NULL");
   }
 
-  @Test public void testCreateTableSelectNonExistingColumnFails() {
+  @Test public void testCreateTableSelectNonExistentColumnFails() {
     String ddl = "create table foo(x int, y varchar)";
     String query = "select ^z^ from foo";
     sql(ddl).ok();

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -101,4 +101,29 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + "FROM `GHI` AS `GHI`";
     sql(sql).rewritesTo(expected);
   }
+
+  @Test public void testCreateTableNoColumns() {
+    String ddl = "create table foo";
+    String query = "select * from foo";
+    sql(ddl).ok();
+    sql(query).type("RecordType() NOT NULL");
+  }
+
+  @Test public void testCreateTableWithColumns() {
+    String ddl = "create table foo(x int, y varchar)";
+    sql(ddl).ok();
+
+    String query = "select x from foo";
+    sql(query).type("RecordType(INTEGER NOT NULL X) NOT NULL");
+
+    String query2 = "select y from foo";
+    sql(query2).type("RecordType(VARCHAR NOT NULL Y) NOT NULL");
+
+    String query3 = "insert into foo values (1, 'str')";
+    sql(query3).type("RecordType(INTEGER NOT NULL X, VARCHAR NOT NULL Y)"
+        + " NOT NULL");
+
+    String query4 = "select ^z^ from foo";
+    sql(query4).fails("Column 'Z' not found in any table");
+  }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -101,4 +101,9 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + "FROM `GHI` AS `GHI`";
     sql(sql).rewritesTo(expected);
   }
+
+  @Test public void testCreateTable() {
+    String sql = "create table foo";
+    sql(sql).ok();
+  }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -123,7 +123,10 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     sql(query3).type("RecordType(INTEGER NOT NULL X, VARCHAR NOT NULL Y)"
         + " NOT NULL");
 
-    String query4 = "select ^z^ from foo";
-    sql(query4).fails("Column 'Z' not found in any table");
+    String query4 = "insert into foo values (1, 'str', 1)";
+    sql(query4).fails("end index \\(3\\) must not be greater than size \\(2\\)");
+
+    String query5 = "select ^z^ from foo";
+    sql(query5).fails("Column 'Z' not found in any table");
   }
 }


### PR DESCRIPTION
- Created new class ExplicitRowTypeTable that extends from Table
- Add validation logic to SqlCreateTable that creates an instance of ExplicitRowTypeTable and adds it to the schema
- Added tests