### PR TITLE
[CALCITE]  Handle INSERT INTO with unspecified column list

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.sql.validate;
 
-import com.sun.org.apache.bcel.internal.classfile.Unknown;
-
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.function.Function2;

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4487,8 +4487,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     final RelDataType targetRowTypeToValidate;
     if (logicalTargetRowType instanceof UnknownRecordType) {
       targetRowTypeToValidate = logicalSourceRowType;
-    } else if (logicalSourceRowType.getFieldCount() ==
-        logicalTargetRowType.getFieldCount()) {
+    } else if (logicalSourceRowType.getFieldCount()
+        == logicalTargetRowType.getFieldCount()) {
       targetRowTypeToValidate = logicalTargetRowType;
     } else {
       targetRowTypeToValidate = realTargetRowType;
@@ -4627,7 +4627,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       List<ColumnStrategy> strategies, RelDataType targetRowTypeToValidate,
       RelDataType realTargetRowType, SqlNode source,
       RelDataType logicalSourceRowType, RelDataType logicalTargetRowType) {
-    if (table.getRowType() instanceof UnknownRecordType) {
+    if (table.getRowType() instanceof UnknownRecordType
+        && logicalTargetRowType.getFieldCount() == 0) {
       return;
     }
     final int sourceFieldCount = logicalSourceRowType.getFieldCount();

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -229,4 +229,13 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
         .withValidatorIdentifierExpansion(true)
         .rewritesTo(expected);
   }
+
+  @Test public void testUnknownTableInsertIntoUnspecifiedColumns() {
+    String sql = "INSERT INTO foo VALUES(1, 'a', CURRENT_DATE)";
+    String expected = "INSERT INTO `FOO`\n"
+        + "VALUES ROW(1, 'a', CURRENT_DATE)";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -238,4 +238,11 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
         .withValidatorIdentifierExpansion(true)
         .rewritesTo(expected);
   }
+
+  @Test public void testUnknownTableInsertMismatch() {
+    String sql = "INSERT INTO ^foo^ (a, b, c) VALUES (1, 2, 3, 4)";
+    String expected = "Number of INSERT target columns \\(3\\) does not equal number of source "
+        + "items \\(4\\)";
+    sql(sql).fails(expected);
+  }
 }


### PR DESCRIPTION
Handles INSERT queries into unknown tables where the column list is not specified. For example:
INSERT INTO foo VALUES (1, 2, 3)