### PR TITLE
[CALCITE] Unknown compound identifiers

### DIFF
--- a/core/src/main/java/org/apache/calcite/schema/impl/UnknownPlaceholderTable.java
+++ b/core/src/main/java/org/apache/calcite/schema/impl/UnknownPlaceholderTable.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.schema.impl;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.UnknownRecordType;
+
+/**
+ * Used to represent unknown tables when the {@code allowUnknownTables}
+ * validator config option is enabled.
+ */
+public class UnknownPlaceholderTable extends AbstractTable {
+  private final UnknownRecordType rowType;
+
+  public UnknownPlaceholderTable(RelDataTypeFactory typeFactory) {
+    this.rowType = new UnknownRecordType(typeFactory);
+  }
+
+  @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    return rowType;
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -206,6 +206,31 @@ public class IdentifierNamespace extends AbstractNamespace {
    * @return    A placeholder {@code TableNamespace}.
    */
   private SqlValidatorNamespace getPlaceholderNamespace(SqlIdentifier id) {
+    CalciteSchema parentSchema = getOrCreateParentSchema(id);
+    SqlIdentifier tableId = id.getComponent(id.names.size() - 1);
+    Table table = new UnknownPlaceholderTable(validator.getTypeFactory());
+    SqlValidatorTable valTable = RelOptTableImpl.create(
+        (RelOptSchema) validator.getCatalogReader(),
+        table.getRowType(validator.getTypeFactory()), id.names, null);
+    parentSchema.add(tableId.toString(), table);
+    return new TableNamespace(validator, valTable);
+  }
+
+  /**
+   * Given an identifier, creates the schema chain corresponding to the prefix
+   * list of the identifier, and adds it to the root schema. Any pre-existing
+   * schemas will be retrieved rather than recreated. As an example, if the
+   * identifier is foo.bar.baz, foo will be added as a subschema to the root
+   * schema, bar will be added as a subschema to foo, and then bar will be
+   * returned as the parent schema of baz.
+   * @param id  the identifier for which the parent schema must be created or
+   *            retrieved.
+   * @return    the immediate parent of the object denoted by the identifer -
+   *            in other words, the schema corresponding to the second to last
+   *            component of the identifier. If the identifier consists of only
+   *            a single name, the root schema will be returned.
+   */
+  public CalciteSchema getOrCreateParentSchema(SqlIdentifier id) {
     CalciteSchema parentSchema =
         getValidator().getCatalogReader().getRootSchema();
     //add chain of subschemas corresponding to identifier prefixes
@@ -216,14 +241,7 @@ public class IdentifierNamespace extends AbstractNamespace {
       }
       parentSchema = parentSchema.getSubSchema(id.names.get(i), false);
     }
-    //handle creating actual table representation
-    SqlIdentifier tableId = id.getComponent(id.names.size() - 1);
-    Table table = new UnknownPlaceholderTable(validator.getTypeFactory());
-    SqlValidatorTable valTable = RelOptTableImpl.create(
-        (RelOptSchema) validator.getCatalogReader(),
-        table.getRowType(validator.getTypeFactory()), id.names, null);
-    parentSchema.add(tableId.toString(), table);
-    return new TableNamespace(validator, valTable);
+    return parentSchema;
   }
 
   public RelDataType validateImpl(RelDataType targetRowType) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -16,11 +16,14 @@
  */
 package org.apache.calcite.sql.validate;
 
+import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.prepare.RelOptTableImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rel.type.UnknownRecordType;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.UnknownPlaceholderTable;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -32,7 +35,6 @@ import org.apache.calcite.util.Pair;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -204,11 +206,24 @@ public class IdentifierNamespace extends AbstractNamespace {
    * @return    A placeholder {@code TableNamespace}.
    */
   private SqlValidatorNamespace getPlaceholderNamespace(SqlIdentifier id) {
-    SqlValidatorTable table = RelOptTableImpl.create(
+    CalciteSchema parentSchema =
+        getValidator().getCatalogReader().getRootSchema();
+    //add chain of subschemas corresponding to identifier prefixes
+    for (int i = 0; i < id.names.size() - 1; i++) {
+      //check that subschema is not already present before adding
+      if (parentSchema.getSubSchema(id.names.get(i), false) == null) {
+        parentSchema.add(id.names.get(i), new AbstractSchema());
+      }
+      parentSchema = parentSchema.getSubSchema(id.names.get(i), false);
+    }
+    //handle creating actual table representation
+    SqlIdentifier tableId = id.getComponent(id.names.size() - 1);
+    Table table = new UnknownPlaceholderTable(validator.getTypeFactory());
+    SqlValidatorTable valTable = RelOptTableImpl.create(
         (RelOptSchema) validator.getCatalogReader(),
-        new UnknownRecordType(validator.getTypeFactory()),
-        Arrays.asList(id.toString()), null);
-    return new TableNamespace(validator, table);
+        table.getRowType(validator.getTypeFactory()), id.names, null);
+    parentSchema.add(tableId.toString(), table);
+    return new TableNamespace(validator, valTable);
   }
 
   public RelDataType validateImpl(RelDataType targetRowType) {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql.validate;
 
 import org.apache.calcite.config.NullCollation;
+import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -815,6 +816,8 @@ public interface SqlValidator {
   void validateSequenceValue(SqlValidatorScope scope, SqlIdentifier id);
 
   SqlValidatorScope getWithScope(SqlNode withItem);
+
+  CalciteSchema getOrCreateParentSchema(SqlIdentifier id);
 
   /**
    * Sets whether this validator should be lenient upon encountering an unknown

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -3995,13 +3995,16 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   @Override public CalciteSchema getOrCreateParentSchema(SqlIdentifier id) {
     CalciteSchema parentSchema =
         getCatalogReader().getRootSchema();
-    //add chain of subschemas corresponding to identifier prefixes
+    // Add chain of subschemas corresponding to identifier prefixes
     for (int i = 0; i < id.names.size() - 1; i++) {
-      //check that subschema is not already present before adding
-      if (parentSchema.getSubSchema(id.names.get(i), false) == null) {
-        parentSchema.add(id.names.get(i), new AbstractSchema());
+      String currentName = id.names.get(i);
+      // Check that subschema is not already present before adding
+      if (parentSchema.getSubSchema(currentName, /*caseSensitive=*/false)
+          == null) {
+        parentSchema.add(currentName, new AbstractSchema());
       }
-      parentSchema = parentSchema.getSubSchema(id.names.get(i), false);
+      parentSchema = parentSchema.getSubSchema(currentName,
+          /*caseSensitive=*/false);
     }
     return parentSchema;
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -91,20 +91,20 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
   @Test public void testUnknownTableMerge() {
     String sql = "MERGE INTO foo AS f USING dept AS b ON f.bar = b.name"
         + " WHEN MATCHED THEN UPDATE SET baz = b.deptno";
-    String expected = "(DynamicRecordRow[]) NOT NULL";
+    String expected = "(DynamicRecordRow[BAZ, BAR, **]) NOT NULL";
     sql(sql).type(expected);
   }
 
   @Test public void testUnknownTableMergeUsingUnknownTable() {
     String sql = "MERGE INTO bar AS b USING foo AS f ON f.x = b.y"
         + " WHEN MATCHED THEN UPDATE SET u = v";
-    String expected = "(DynamicRecordRow[]) NOT NULL";
+    String expected = "(DynamicRecordRow[U, Y, **]) NOT NULL";
     sql(sql).type(expected);
   }
 
   @Test public void testUnknownTableUpdate() {
     String sql = "UPDATE foo SET bar = 5 WHERE baz = 7";
-    String expected = "(DynamicRecordRow[BAR]) NOT NULL";
+    String expected = "(DynamicRecordRow[BAR, BAZ, **]) NOT NULL";
     sql(sql).type(expected);
   }
 
@@ -116,7 +116,7 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
 
   @Test public void testUnknownTableDelete() {
     String sql = "DELETE FROM foo WHERE bar = 5";
-    String expected = "(DynamicRecordRow[]) NOT NULL";
+    String expected = "(DynamicRecordRow[BAR, **]) NOT NULL";
     sql(sql).type(expected);
   }
 
@@ -225,6 +225,24 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
         + "FROM `FOO` AS `FOO`\n"
         + "INNER JOIN `CATALOG`.`SALES`.`DEPT` AS `DEPT`"
         + " ON `DEPT`.`DEPTNO` = `FOO`.`X`";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
+
+  @Test public void testUnknownTableWithUnknownSchema() {
+    String sql = "select * from INFORMATION_SCHEMA.COLUMNS";
+    String expected = "SELECT *\n"
+        + "FROM `INFORMATION_SCHEMA`.`COLUMNS` AS `COLUMNS`";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
+
+  @Test public void testUnknownTableWithUnknownSchemaAndSubschema() {
+    String sql = "select * from foo.bar.baz";
+    String expected = "SELECT *\n"
+        + "FROM `FOO`.`BAR`.`BAZ` AS `BAZ`";
     sql(sql)
         .withValidatorIdentifierExpansion(true)
         .rewritesTo(expected);


### PR DESCRIPTION
When tables are specified via compound identifiers like foo.bar, this will now result in prefixes getting added as subschemas to the root schema, and tables getting added to the appropriate subschemas (ex. "foo" will be added as a subschema to the root, and "bar" will be added as a table to subschema "foo").