### PR TITLE
[CALCITE] Handle resignal validation scenario

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSignal.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSignal.java
@@ -77,7 +77,9 @@ public class SqlSignal extends SqlScriptingNode {
       return;
     }
     BlockScope bs = (BlockScope) scope;
-    conditionDeclaration = bs.findConditionDeclaration(conditionOrSqlState);
+    if (conditionOrSqlState != null) {
+      conditionDeclaration = bs.findConditionDeclaration(conditionOrSqlState);
+    }
   }
 
   public enum SignalType {

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -313,7 +313,7 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + "b.x when matched then update set y = b.y when not matched then "
         + "insert (x,y) values (b.x, b.y)";
     String expected = "CREATE PROCEDURE `FOO` ()\n"
-        + "MERGE INTO `T1` AS `A`\n"
+        + "MERGE INTO `CATALOG`.`T1` AS `A`\n"
         + "USING `T2` AS `B`\n"
         + "ON `A`.`X` = `B`.`X`\n"
         + "WHEN MATCHED THEN UPDATE SET `Y` = `B`.`Y`\n"
@@ -399,6 +399,17 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     SqlBeginEndCall beginEnd = (SqlBeginEndCall) node.statement;
     SqlSignal signal = (SqlSignal) beginEnd.statements.get(0);
     assertThat(signal.conditionDeclaration, nullValue());
+  }
+
+  @Test public void testCreateProcedureConditionResignalNull() {
+    String sql = "create procedure foo()\n"
+        + "begin\n"
+        + "resignal;\n"
+        + "end";
+    SqlCreateProcedure node = (SqlCreateProcedure) parseAndValidate(sql);
+    SqlBeginEndCall beginEnd = (SqlBeginEndCall) node.statement;
+    SqlSignal resignal = (SqlSignal) beginEnd.statements.get(0);
+    assertThat(resignal.conditionDeclaration, nullValue());
   }
 
   @Test public void testCreateProcedureConditionHandler() {


### PR DESCRIPTION
Also temporarily modifies the testCreateProcedureMerge() unit test to workaround a bug that may have been introduced by https://github.com/googleinterns/calcite/pull/323/