### PR TITLE
[CALCITE] Handle validation of CAST calls without a data type

### DIFF
--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -502,4 +502,13 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
     SqlIterateStmt iterate = (SqlIterateStmt) whileLoop.statements.get(0);
     assertThat(iterate.labeledBlock, sameInstance(whileLoop));
   }
+
+  @Test public void testCastWithColumnAttributeFormat() {
+    String sql = "select deptno (format 'YYYYMMDD') from dept";
+    String expectedType = "RecordType(INTEGER NOT NULL EXPR$0) NOT NULL";
+    String expectedRewrite = "SELECT CAST(`DEPT`.`DEPTNO` AS FORMAT "
+        + "'YYYYMMDD')\n"
+        + "FROM `CATALOG`.`SALES`.`DEPT` AS `DEPT`";
+    sql(sql).type(expectedType).rewritesTo(expectedRewrite);
+  }
 }


### PR DESCRIPTION
Some cast calls only have a SqlColumnAttribute as the second operand. In that case, it should return the data type of the first operand.