### PR TITLE
[CALCITE] Fix: Rollback schema construction for unknown tables.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -16,7 +16,6 @@
  */
 package org.apache.calcite.sql.validate;
 
-import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.prepare.RelOptTableImpl;
 import org.apache.calcite.rel.type.RelDataType;

--- a/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/IdentifierNamespace.java
@@ -205,13 +205,10 @@ public class IdentifierNamespace extends AbstractNamespace {
    * @return    A placeholder {@code TableNamespace}.
    */
   private SqlValidatorNamespace getPlaceholderNamespace(SqlIdentifier id) {
-    CalciteSchema parentSchema = validator.getOrCreateParentSchema(id);
-    SqlIdentifier tableId = id.getComponent(id.names.size() - 1);
     Table table = new UnknownPlaceholderTable(validator.getTypeFactory());
     SqlValidatorTable valTable = RelOptTableImpl.create(
         (RelOptSchema) validator.getCatalogReader(),
         table.getRowType(validator.getTypeFactory()), id.names, null);
-    parentSchema.add(tableId.toString(), table);
     return new TableNamespace(validator, valTable);
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -91,20 +91,20 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
   @Test public void testUnknownTableMerge() {
     String sql = "MERGE INTO foo AS f USING dept AS b ON f.bar = b.name"
         + " WHEN MATCHED THEN UPDATE SET baz = b.deptno";
-    String expected = "(DynamicRecordRow[BAZ, BAR, **]) NOT NULL";
+    String expected = "(DynamicRecordRow[]) NOT NULL";
     sql(sql).type(expected);
   }
 
   @Test public void testUnknownTableMergeUsingUnknownTable() {
     String sql = "MERGE INTO bar AS b USING foo AS f ON f.x = b.y"
         + " WHEN MATCHED THEN UPDATE SET u = v";
-    String expected = "(DynamicRecordRow[U, Y, **]) NOT NULL";
+    String expected = "(DynamicRecordRow[]) NOT NULL";
     sql(sql).type(expected);
   }
 
   @Test public void testUnknownTableUpdate() {
     String sql = "UPDATE foo SET bar = 5 WHERE baz = 7";
-    String expected = "(DynamicRecordRow[BAR, BAZ, **]) NOT NULL";
+    String expected = "(DynamicRecordRow[BAR]) NOT NULL";
     sql(sql).type(expected);
   }
 
@@ -116,7 +116,7 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
 
   @Test public void testUnknownTableDelete() {
     String sql = "DELETE FROM foo WHERE bar = 5";
-    String expected = "(DynamicRecordRow[BAR, **]) NOT NULL";
+    String expected = "(DynamicRecordRow[]) NOT NULL";
     sql(sql).type(expected);
   }
 

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -438,7 +438,7 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + "b.x when matched then update set y = b.y when not matched then "
         + "insert (x,y) values (b.x, b.y)";
     String expected = "CREATE PROCEDURE `FOO` ()\n"
-        + "MERGE INTO `CATALOG`.`T1` AS `A`\n"
+        + "MERGE INTO `T1` AS `A`\n"
         + "USING `T2` AS `B`\n"
         + "ON `A`.`X` = `B`.`X`\n"
         + "WHEN MATCHED THEN UPDATE SET `Y` = `B`.`Y`\n"


### PR DESCRIPTION
Previously, unknown tables and subschemas were being attached directly to the root schema - this is not always the correct behavior, so this functionality has been removed.