### PR TITLE
[CALCITE] Fix column expansion from unknown subqueries (remove ** suffix)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -115,7 +115,9 @@ public abstract class RelDataTypeImpl
         return new RelDataTypeFieldImpl(
             fieldName,
             field.getIndex(),
-            ((BasicSqlType) field.getValue()).relaxToAny());
+            new BasicSqlType(((BasicSqlType) field.getValue()).typeSystem, SqlTypeName.ANY,
+                /*nullable=*/true, /*precision=*/-1, /*scale=*/-1,
+                /*collation=*/null, /*wrappedCharset=*/null));
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -115,9 +115,9 @@ public abstract class RelDataTypeImpl
         return new RelDataTypeFieldImpl(
             fieldName,
             field.getIndex(),
-            new BasicSqlType(((BasicSqlType) field.getValue()).typeSystem, SqlTypeName.ANY,
-                /*nullable=*/true, /*precision=*/-1, /*scale=*/-1,
-                /*collation=*/null, /*wrappedCharset=*/null));
+            new BasicSqlType(((BasicSqlType) field.getValue()).typeSystem,
+                SqlTypeName.ANY, /*nullable=*/ true, /*precision=*/ -1,
+                /*scale=*/ -1, /*collation=*/ null, /*wrappedCharset=*/ null));
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeImpl.java
@@ -112,7 +112,10 @@ public abstract class RelDataTypeImpl
     for (RelDataTypeField field : fieldList) {
       if (field.isDynamicStar()) {
         // the requested field could be in the unresolved star
-        return field;
+        return new RelDataTypeFieldImpl(
+            fieldName,
+            field.getIndex(),
+            ((BasicSqlType) field.getValue()).relaxToAny());
       }
     }
 

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -126,6 +126,12 @@ public class BasicSqlType extends AbstractSqlType {
         this.precision, this.scale, this.collation, this.wrappedCharset);
   }
 
+  public BasicSqlType relaxToAny() {
+    return new BasicSqlType(this.typeSystem, SqlTypeName.ANY,
+        /*nullable=*/true, /*precision=*/-1, /*scale=*/-1, /*collation=*/null,
+        /*wrappedCharset=*/null);
+  }
+
   /**
    * Constructs a type with charset and collation.
    *

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -126,12 +126,6 @@ public class BasicSqlType extends AbstractSqlType {
         this.precision, this.scale, this.collation, this.wrappedCharset);
   }
 
-  public BasicSqlType relaxToAny() {
-    return new BasicSqlType(this.typeSystem, SqlTypeName.ANY,
-        /*nullable=*/true, /*precision=*/-1, /*scale=*/-1, /*collation=*/null,
-        /*wrappedCharset=*/null);
-  }
-
   /**
    * Constructs a type with charset and collation.
    *

--- a/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/BasicSqlType.java
@@ -38,7 +38,7 @@ public class BasicSqlType extends AbstractSqlType {
 
   private final int precision;
   private final int scale;
-  private final RelDataTypeSystem typeSystem;
+  public final RelDataTypeSystem typeSystem;
   private final SqlCollation collation;
   private final SerializableCharset wrappedCharset;
 
@@ -96,7 +96,7 @@ public class BasicSqlType extends AbstractSqlType {
   }
 
   /** Internal constructor. */
-  private BasicSqlType(
+  public BasicSqlType(
       RelDataTypeSystem typeSystem,
       SqlTypeName typeName,
       boolean nullable,

--- a/core/src/main/java/org/apache/calcite/sql/validate/DelegatingScope.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/DelegatingScope.java
@@ -536,7 +536,8 @@ public abstract class DelegatingScope implements SqlValidatorScope {
           identifier = identifier.add(k, fieldName, SqlParserPos.ZERO);
           break;
         default:
-          if (!fieldName.equals(name)) {
+          if (!fieldName.equals(name) && !(field0.isDynamicStar()
+              && validator.config().allowUnknownTables())) {
             identifier = identifier.setName(k, fieldName);
           }
           if (hasAmbiguousField(step.rowType, field0, name, nameMatcher)) {

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -239,6 +239,16 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
         .rewritesTo(expected);
   }
 
+  @Test public void testSelectWithUnknownSubquery() {
+    String sql = "with t AS (select * FROM foo) select (select 2 AS x from t where x = 1) from " +
+        "foo";
+    String expected = "SELECT `DEPT`.`DEPTNO`, `DEPT`.`NAME`\n"
+        + "FROM `CATALOG`.`SALES`.`DEPT` AS `DEPT`";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
+
   @Test public void testUnknownTableInsertIntoUnspecifiedColumns() {
     String sql = "INSERT INTO foo VALUES(1, 'a', CURRENT_DATE)";
     String expected = "INSERT INTO `FOO`\n"

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -240,10 +240,23 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
   }
 
   @Test public void testSelectWithUnknownSubquery() {
-    String sql = "with t AS (select * FROM foo) select (select 2 AS x from t where x = 1) from " +
-        "foo";
-    String expected = "SELECT `DEPT`.`DEPTNO`, `DEPT`.`NAME`\n"
-        + "FROM `CATALOG`.`SALES`.`DEPT` AS `DEPT`";
+    String sql = "with t AS (select * FROM foo) select (select 2 AS x from t where x = 1) from "
+        + "foo";
+    String expected = "WITH `T` AS (SELECT *\n"
+        + "FROM `FOO` AS `FOO`) (SELECT (((SELECT 2 AS `X`\n"
+        + "FROM `T` AS `T`\n"
+        + "WHERE `T`.`X` = 1)))\n"
+        + "FROM `FOO` AS `FOO`)";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
+
+  @Test public void testSelectFromUnknownSubquery() {
+    String sql = "SELECT f.x FROM (SELECT * FROM foo) AS f";
+    String expected = "SELECT `F`.`X`\n"
+        + "FROM (SELECT *\n"
+        + "FROM `FOO` AS `FOO`) AS `F`";
     sql(sql)
         .withValidatorIdentifierExpansion(true)
         .rewritesTo(expected);

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorBestEffortTest.java
@@ -240,8 +240,8 @@ public class SqlValidatorBestEffortTest extends SqlValidatorTestCase {
   }
 
   @Test public void testSelectWithUnknownSubquery() {
-    String sql = "with t AS (select * FROM foo) select (select 2 AS x from t where x = 1) from "
-        + "foo";
+    String sql = "with t AS (select * FROM foo) select "
+        + "(select 2 AS x from t where x = 1) from  foo";
     String expected = "WITH `T` AS (SELECT *\n"
         + "FROM `FOO` AS `FOO`) (SELECT (((SELECT 2 AS `X`\n"
         + "FROM `T` AS `T`\n"

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -633,4 +633,17 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         + "VALUES ROW(1, 'a', CURRENT_DATE)";
     sql(sql).rewritesTo(expected);
   }
+
+  @Test public void testSelectWithUnknownSubquery() {
+    String sql = "with t AS (select * FROM foo) select "
+        + "(select 2 AS x from t where x = 1) from  foo";
+    String expected = "WITH `T` AS (SELECT *\n"
+        + "FROM `FOO` AS `FOO`) (SELECT (((SELECT 2 AS `X`\n"
+        + "FROM `T` AS `T`\n"
+        + "WHERE `T`.`X` = 1)))\n"
+        + "FROM `FOO` AS `FOO`)";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
 }

--- a/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
+++ b/parsing/dialects/intermediate/dialects/dialect1/src/test/java/org/apache/calcite/test/Dialect1ValidatorTest.java
@@ -646,4 +646,14 @@ public class Dialect1ValidatorTest extends SqlValidatorTestCase {
         .withValidatorIdentifierExpansion(true)
         .rewritesTo(expected);
   }
+
+  @Test public void testSelectFromUnknownSubquery() {
+    String sql = "SELECT f.x FROM (SELECT * FROM foo) AS f";
+    String expected = "SELECT `F`.`X`\n"
+        + "FROM (SELECT *\n"
+        + "FROM `FOO` AS `FOO`) AS `F`";
+    sql(sql)
+        .withValidatorIdentifierExpansion(true)
+        .rewritesTo(expected);
+  }
 }


### PR DESCRIPTION
Columns deriving from unknown subqueries no longer be rewritten with the ** prefix.