### PR TITLE
[CALCITE] Ensured invalid rank() call still fails even when aliased.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -51,6 +51,7 @@ import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlAccessEnum;
 import org.apache.calcite.sql.SqlAccessType;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlAsOperator;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
@@ -4527,7 +4528,13 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
    */
   private void validateExpr(SqlNode expr, SqlValidatorScope scope) {
     if (expr instanceof SqlCall) {
-      final SqlOperator op = ((SqlCall) expr).getOperator();
+      SqlOperator op = ((SqlCall) expr).getOperator();
+      if (op instanceof SqlAsOperator) {
+        SqlNode aliasedNode = ((SqlCall) expr).getOperandList().get(0);
+        if (aliasedNode instanceof SqlCall) {
+          op = ((SqlCall) aliasedNode).getOperator();
+        }
+      }
       if (op.isAggregator() && op.requiresOver()) {
         throw newValidationError(expr,
             RESOURCE.absentOverClause());

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -11128,4 +11128,11 @@ class SqlValidatorTest extends SqlValidatorTestCase {
         .withConformance(SqlConformanceEnum.LENIENT)
         .rewritesTo(expected);
   }
+
+  @Test public void testAliasedRankFailsWithoutOverClause() {
+    String sql = "select ^rank() as r^ from emp";
+    String expected = "OVER clause is necessary for window functions";
+    sql(sql)
+        .fails(expected);
+  }
 }


### PR DESCRIPTION
Currently, queries like
SELECT rank() from emp
will fail (because you need an OVER clause), but aliased queries like
SELECT rank() as r from emp
will not. The query is semantically identical, so this fix ensures that the query will fail in either case.